### PR TITLE
fix(deploy): ensure MONGODB_URI is correctly used and add safety check

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -62,7 +62,7 @@ jobs:
           NEON_REFRESH_TOKEN: ${{ secrets.NEON_REFRESH_TOKEN }}
           NEON_AUTH_USER_ID: ${{ secrets.NEON_AUTH_USER_ID }}
           APP_DEPLOYMENT_MODE: ${{ secrets.REACT_APP_DEPLOYMENT_MODE }}
-          REACT_APP_MONGODB_URI: ${{ secrets.REACT_APP_MONGODB_URI }}
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
 
       - name: Deploy with Edge Config updates
         if: steps.set-env.outputs.should_deploy == 'true'
@@ -78,6 +78,7 @@ jobs:
           NEON_REFRESH_TOKEN: ${{ secrets.NEON_REFRESH_TOKEN }}
           NEON_AUTH_USER_ID: ${{ secrets.NEON_AUTH_USER_ID }}
           APP_DEPLOYMENT_MODE: ${{ secrets.REACT_APP_DEPLOYMENT_MODE }}
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
 
       - name: Deployment Summary
         if: steps.set-env.outputs.should_deploy == 'true' && success()

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,6 +26,7 @@ NEON_SECRET_SERVER_KEY=${NEON_SECRET_SERVER_KEY:-$STACK_SECRET_SERVER_KEY}
 NEON_REFRESH_TOKEN=${NEON_REFRESH_TOKEN:-$NEON_REFRESH_TOKEN}
 NEON_AUTH_USER_ID=${NEON_AUTH_USER_ID:-$NEON_AUTH_USER_ID}
 APP_DEPLOYMENT_MODE=${APP_DEPLOYMENT_MODE:-${REACT_APP_DEPLOYMENT_MODE:-development}}
+MONGODB_URI=${MONGODB_URI:-$MONGODB_URI}
 
 YEAR_DIGIT=$(date +"%Y" | grep -o '.$')
 MONTH_DAY=$(date +"%m%d")
@@ -62,18 +63,21 @@ else
 fi
 
 echo "=== Exporting version to MongoDB ==="
-MONGO_URI=${REACT_APP_MONGODB_URI:-$MONGODB_URI}
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-MONGO_RESULT=$(mongosh "$MONGO_URI" --quiet --eval \
-  "db.getSiblingDB('main').versions.insertOne({ version: '$VERSION', timestamp: '$TIMESTAMP', deployedAt: new Date() })" 2>&1)
-
-if [[ $? -eq 0 ]]; then
-  echo "=== MongoDB version exported successfully ==="
+if [[ -z "$MONGODB_URI" ]]; then
+  echo "=== MongoDB export skipped: MONGODB_URI is not set ==="
 else
-  echo "=== MongoDB export failed ==="
-  echo "$MONGO_RESULT"
-  exit 1
+  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  MONGO_RESULT=$(mongosh "$MONGODB_URI" --quiet --eval \
+    "db.getSiblingDB('main').versions.insertOne({ version: '$VERSION', timestamp: '$TIMESTAMP', deployedAt: new Date() })" 2>&1)
+
+  if [[ $? -eq 0 ]]; then
+    echo "=== MongoDB version exported successfully ==="
+  else
+    echo "=== MongoDB export failed ==="
+    echo "$MONGO_RESULT"
+    exit 1
+  fi
 fi
 
 # echo "=== Exporting version to Neon ==="


### PR DESCRIPTION
- Fix a bug in `deploy.sh` where the MongoDB export failed due to an undefined `MONGO_URI` variable.
- Add a safety check to skip the MongoDB version export if `MONGODB_URI` is not set in the environment.
- Initialize `MONGODB_URI` at the top of the script to ensure environment variables are correctly inherited.