### PR TITLE
chore(config): increase edge config fetch delay for propagation

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -27,8 +27,8 @@ else
 fi
 
 echo "Fetching version from Vercel Edge Config..."
-# Add a 10-second delay before fetching data
-sleep 10
+# Add a 30-second delay before fetching data
+sleep 30
 
 FETCHED_DATA=$(curl -s "https://edge-config.vercel.com/${EDGE_ID}/items" \
      -H "Authorization: Bearer $EDGE_READ_TOKEN")


### PR DESCRIPTION
- Update `config.sh` to sleep for 30 seconds (up from 10s) before fetching from Vercel Edge Config.
- This ensures the updated configuration and version data have sufficient time to propagate across Vercel's edge network after a deployment.