### PR TITLE
Promote processed data metadata validation to stage

### DIFF
--- a/src/composables/useDataStore.ts
+++ b/src/composables/useDataStore.ts
@@ -25,7 +25,10 @@ import { IPVPDataModel } from '../core/models/pvp.model';
 import { IStatsRank } from '../core/models/stats.model';
 import { StoreActions, StatsActions, TimestampActions } from '../store/actions';
 import { createProgressHelpers } from '../utils/helpers/progress-helpers';
-import ProcessedDataService, { ProcessedDataSection } from '../services/processed-data.service';
+import ProcessedDataService, {
+  ProcessedDataSection,
+  UnsupportedProcessedDataSchemaError,
+} from '../services/processed-data.service';
 
 /**
  * Custom hook to access and update the data from Redux store
@@ -172,11 +175,16 @@ export const useDataStore = () => {
       dispatch(TimestampActions.SetSnapshotGeneratedAt.create(meta.generatedAt));
       dispatch(TimestampActions.SetTimestampGameMaster.create(meta.source.gameMaster));
       dispatch(TimestampActions.SetTimestampAssets.create(meta.source.assets));
+      dispatch(StoreActions.SetLogoPokeGO.create(meta.appIcon ?? ''));
+      dispatch(TimestampActions.SetTimestampIcon.create(meta.source.icon ?? 0));
       dispatch(TimestampActions.SetTimestampSounds.create(meta.source.sounds));
       dispatch(TimestampActions.SetTimestampPVP.create(meta.source.pvp));
       completeProgress();
       return true;
-    } catch {
+    } catch (error) {
+      if (error instanceof UnsupportedProcessedDataSchemaError) {
+        throw error;
+      }
       return false;
     }
   };

--- a/src/composables/useTimestamp.ts
+++ b/src/composables/useTimestamp.ts
@@ -69,7 +69,7 @@ export const useTimestamp = () => {
         errorProgress({ isError: true, message: 'Processed data API is unavailable.' });
       }
     } catch (e) {
-      errorProgress({ isError: true, message: (e as ErrorEvent).message });
+      errorProgress({ isError: true, message: e instanceof Error ? e.message : String(e) });
     }
   };
 

--- a/src/services/processed-data.service.ts
+++ b/src/services/processed-data.service.ts
@@ -2,13 +2,27 @@ import APIService from './api.service';
 import { APIUrl } from './constants';
 import type { AxiosRequestConfig } from 'axios';
 
+export const PROCESSED_DATA_SCHEMA_VERSION = 3;
+
+export class UnsupportedProcessedDataSchemaError extends Error {
+  constructor(actualVersion: unknown) {
+    super(
+      `Processed data schema ${String(actualVersion ?? 'unknown')} is not supported. ` +
+        `This web version requires schema ${PROCESSED_DATA_SCHEMA_VERSION}.`
+    );
+    this.name = 'UnsupportedProcessedDataSchemaError';
+  }
+}
+
 export interface ProcessedDataMeta {
   schemaVersion: number;
   webVersion: string | null;
   generatedAt: string;
+  appIcon?: string;
   source: {
     gameMaster: number;
     assets: number;
+    icon?: number;
     sounds: number;
     pvp: number;
   };
@@ -49,6 +63,9 @@ class ProcessedDataService {
 
   async getMeta() {
     const meta = (await APIService.getFetchUrl<ProcessedDataMeta>(endpoint('meta'))).data;
+    if (meta.schemaVersion !== PROCESSED_DATA_SCHEMA_VERSION) {
+      throw new UnsupportedProcessedDataSchemaError(meta.schemaVersion);
+    }
     if (this.generatedAt && this.generatedAt !== meta.generatedAt) {
       this.sectionRequests.clear();
     }


### PR DESCRIPTION
Promotes develop to stage.\n\n- Hydrate the Pokémon GO app icon from API metadata\n- Validate processed-data schema compatibility\n- Preserve a distinct unsupported-schema error