### PR TITLE
Promote server-side Tools processing to stage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,6 @@
 # NOTE: Never commit .env file to version control
 
 # ====================
-# GitHub & Repository
-# ====================
-
-# Optional GitHub token for private repository access.
-# Public GitHub APIs used by the app do not need this value.
-REACT_APP_TOKEN_PRIVATE_REPO=
-
-# ====================
 # Vercel Edge Config
 # ====================
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,6 @@ env:
   # App env vars (available to all jobs via global env)
   REACT_APP_DEPLOYMENT_MODE: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'stage' && 'staging' || 'development' }}
   APP_DEPLOYMENT_MODE: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'stage' && 'staging' || 'development' }}
-  REACT_APP_TOKEN_PRIVATE_REPO: ${{ secrets.REACT_APP_TOKEN_PRIVATE_REPO }}
-  REACT_APP_POKEGO_BREEZE_DB_URL: ${{ secrets.REACT_APP_POKEGO_BREEZE_DB_URL }}
-  REACT_APP_EDGE_CONFIG: ${{ secrets.REACT_APP_EDGE_CONFIG }}
   REACT_APP_EDGE_ID: ${{ secrets.REACT_APP_EDGE_ID }}
   REACT_APP_EDGE_READ_TOKEN: ${{ secrets.REACT_APP_EDGE_READ_TOKEN }}
   REACT_APP_ENCRYPTION_KEY: ${{ secrets.REACT_APP_ENCRYPTION_KEY }}

--- a/README.md
+++ b/README.md
@@ -378,17 +378,13 @@ npm install
 
    | Variable | Required | Purpose |
    |---|---|---|
-   | `REACT_APP_TOKEN_PRIVATE_REPO` | No | Optional GitHub token for private repo access; public GitHub APIs do not need it |
    | `REACT_APP_ENCRYPTION_KEY` | Yes | AES encryption key (40+ chars) |
    | `REACT_APP_ENCRYPTION_SALT` | Yes | AES encryption salt (40+ chars) |
    | `REACT_APP_DEPLOYMENT_MODE` | Yes | `development` \| `staging` \| `production` |
    | `REACT_APP_BASE_URL` | Yes | Application base URL |
-   | `REACT_APP_EDGE_CONFIG` | Yes | Vercel Edge Config connection string |
    | `REACT_APP_EDGE_TOKEN` | Yes | Edge Config write token (deploy.sh) |
    | `REACT_APP_EDGE_READ_TOKEN` | Yes | Edge Config read token (config.sh) |
    | `REACT_APP_EDGE_ID` | Yes | Edge Config ID (e.g. `ecfg_xxx`) |
-   | `REACT_APP_POKEGO_BREEZE_DB_URL` | Yes | PokeGoBreeze database URL |
-   | `REACT_APP_NEON_API_URL` | Yes | Neon serverless Postgres API URL |
    | `REACT_APP_VERSION` | No | App version override (e.g. `1.0.0`) |
    | `REACT_APP_REDUX_VERBOSE` | No | `true` = show full Redux store in DevTools (default `false`) |
    | `MONGODB_URI` | No | MongoDB connection string (deploy.sh version history) |

--- a/src/pages/Sheets/DpsTdo/DpsTdo.tsx
+++ b/src/pages/Sheets/DpsTdo/DpsTdo.tsx
@@ -515,7 +515,7 @@ const DpsTdo = () => {
   return (
     <div className="tw-relative">
       <div className="tw-relative tw-text-center tw-w-full">
-        {!isNotEmpty(dpsTable) && (
+        {isShowSpinner && !isNotEmpty(dpsTable) && (
           <div className="slide-container !tw-p-0 !tw-w-full !tw-h-full !tw-absolute tw-z-2 !tw-bg-spinner-default">
             <Skeleton variant="rectangular" animation="wave" className="!tw-w-full !tw-h-full !tw-m-0 !tw-p-0" />
           </div>
@@ -1054,7 +1054,7 @@ const DpsTdo = () => {
         <CustomDataTable
           customColumns={columns}
           data={dpsTable}
-          noDataComponent={null}
+          noDataComponent={<div className="tw-p-6 tw-text-center">No Pokémon match the selected filters.</div>}
           pagination
           paginationServer
           paginationTotalRows={totalRows}

--- a/src/pages/Tools/BattleDamage/Damage.tsx
+++ b/src/pages/Tools/BattleDamage/Damage.tsx
@@ -1,8 +1,7 @@
 import { Checkbox, FormControlLabel, Switch } from '@mui/material';
-import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { Fragment, useCallback, useMemo, useState } from 'react';
 
-import { capitalize, getDmgMultiplyBonus, getKeyWithData, LevelRating } from '../../../utils/utils';
-import { calculateDamagePVE, calculateStatsBattle, getTypeEffective } from '../../../utils/calculate';
+import { capitalize, getKeyWithData, LevelRating } from '../../../utils/utils';
 
 import './Damage.scss';
 import TypeInfo from '../../../components/Sprites/Type/Type';
@@ -17,7 +16,7 @@ import StatsDamageTable from './StatsDamageTable';
 import SelectCustomMove from '../../../components/Commons/Selects/SelectCustomMove';
 import { findStabType } from '../../../utils/compute';
 import { ICombat } from '../../../core/models/combat.model';
-import { BattleState, ILabelDamage, LabelDamage, PokemonDmgOption } from '../../../core/models/damage.model';
+import { ILabelDamage, LabelDamage, PokemonDmgOption } from '../../../core/models/damage.model';
 import { useTitle } from '../../../utils/hooks/useTitle';
 import {
   combineClasses,
@@ -27,12 +26,20 @@ import {
   safeObjectEntries,
   toNumber,
 } from '../../../utils/extension';
-import { PokemonType, ThrowType, TypeAction, TypeMove } from '../../../enums/type.enum';
-import { getMultiplyFriendship, getThrowCharge, maxIv } from '../../../utils/helpers/options-context.helpers';
+import { PokemonType, ThrowType, TypeMove } from '../../../enums/type.enum';
+import {
+  defaultMegaMultiply,
+  defaultTrainerMultiply,
+  getMultiplyFriendship,
+  getThrowCharge,
+  maxIv,
+} from '../../../utils/helpers/options-context.helpers';
 import useSearch from '../../../composables/useSearch';
 import SelectMui from '../../../components/Commons/Selects/SelectMui';
 import ButtonMui from '../../../components/Commons/Buttons/ButtonMui';
 import { useSnackbar } from '../../../contexts/snackbar.context';
+import APIService from '../../../services/api.service';
+import useSpinner from '../../../composables/useSpinner';
 
 const labels: DynamicObj<ILabelDamage> = {
   0: LabelDamage.create({
@@ -93,13 +100,8 @@ const Damage = () => {
 
   const [move, setMove] = useState<ICombat>();
 
-  const [statLvATK, setStatLvATK] = useState(0);
-
   const [statLevel, setStatLevel] = useState(1);
   const [statType, setStatType] = useState(PokemonType.Normal);
-
-  const [statLvDEFObj, setStatLvDEFObj] = useState(0);
-  const [statLvSTAObj, setStatLvSTAObj] = useState(0);
 
   const [statLevelObj, setStatLevelObj] = useState(1);
   const [statTypeObj, setStatTypeObj] = useState(PokemonType.Normal);
@@ -110,6 +112,7 @@ const Damage = () => {
   const [result, setResult] = useState(new PokemonDmgOption());
 
   const { showSnackbar } = useSnackbar();
+  const { showSpinner, hideSpinner } = useSpinner();
 
   const throwChargeMenuItems = useMemo(
     () =>
@@ -126,45 +129,6 @@ const Damage = () => {
     []
   );
 
-  useEffect(() => {
-    if (searchingToolCurrentData?.pokemon?.statsGO?.atk !== 0) {
-      setStatLvATK(
-        calculateStatsBattle(
-          searchingToolCurrentData?.pokemon?.statsGO?.atk,
-          maxIv(),
-          statLevel,
-          false,
-          getDmgMultiplyBonus(statType, TypeAction.Atk)
-        )
-      );
-    }
-    if (searchingToolObjectData?.pokemon?.statsGO?.def !== 0) {
-      setStatLvDEFObj(
-        calculateStatsBattle(
-          searchingToolObjectData?.pokemon?.statsGO?.def,
-          maxIv(),
-          statLevelObj,
-          false,
-          getDmgMultiplyBonus(statType, TypeAction.Def)
-        )
-      );
-    }
-    if (searchingToolObjectData?.pokemon?.statsGO?.sta !== 0) {
-      setStatLvSTAObj(calculateStatsBattle(searchingToolObjectData?.pokemon?.statsGO?.sta, maxIv(), statLevelObj));
-    }
-  }, [
-    searchingToolCurrentData?.pokemon?.statsGO?.atk,
-    statLevel,
-    statType,
-    searchingToolObjectData?.pokemon?.statsGO?.atk,
-    searchingToolCurrentData?.pokemon?.statsGO?.def,
-    searchingToolObjectData?.pokemon?.statsGO?.def,
-    statLevelObj,
-    searchingToolCurrentData?.pokemon?.statsGO?.sta,
-    searchingToolObjectData?.pokemon?.statsGO?.sta,
-    statTypeObj,
-  ]);
-
   const clearData = () => {
     setResult(new PokemonDmgOption());
   };
@@ -175,26 +139,59 @@ const Damage = () => {
   };
 
   const onCalculateDamagePoke = useCallback(
-    (e: React.SyntheticEvent<HTMLFormElement>) => {
+    async (e: React.SyntheticEvent<HTMLFormElement>) => {
       e.preventDefault();
-      if (move) {
-        const eff = BattleState.create({
-          isStab: findStabType(searchingToolCurrentData?.form?.form?.types, move.type),
-          isWb: battleState.isWeather,
-          isDodge: battleState.isDodge,
-          isMega: searchingToolCurrentData?.form?.form?.pokemonType === PokemonType.Mega,
-          isTrainer: battleState.isTrainer,
-          friendshipLevel: enableFriend ? battleState.friendshipLevel : 0,
-          throwLevel: battleState.throwLevel,
-          effective: getTypeEffective(move.type, searchingToolObjectData?.form?.form?.types),
+      if (!move) {
+        showSnackbar('Please select move for pokémon!', 'error');
+        return;
+      }
+      const attacker = searchingToolCurrentData?.pokemon?.statsGO;
+      const defender = searchingToolObjectData?.pokemon?.statsGO;
+      if (!attacker || !defender) {
+        showSnackbar('Please select attacker and defender Pokémon!', 'error');
+        return;
+      }
+      showSpinner();
+      try {
+        const response = await APIService.postDamageSimulator({
+          mode: 'damage',
+          attacker: {
+            base: attacker,
+            level: statLevel,
+            pokemonType: statType,
+            types: searchingToolCurrentData?.form?.form?.types ?? [],
+          },
+          defender: {
+            base: defender,
+            level: statLevelObj,
+            pokemonType: statTypeObj,
+            types: searchingToolObjectData?.form?.form?.types ?? [],
+          },
+          move: { type: getValueOrDefault(String, move.type), power: move.pvePower },
+          battle: {
+            isWb: battleState.isWeather,
+            isDodge: battleState.isDodge,
+            isTrainer: battleState.isTrainer,
+            friendshipLevel: enableFriend ? battleState.friendshipLevel : 0,
+            throwLevel: battleState.throwLevel,
+            isMega: searchingToolCurrentData?.form?.form?.pokemonType === PokemonType.Mega,
+          },
+          config: {
+            iv: maxIv(),
+            trainerMultiplier: defaultTrainerMultiply(),
+            megaMultiplier: defaultMegaMultiply(),
+          },
         });
-        setResult((r) =>
+        const data = response.data.data;
+        if (data.mode !== 'damage') {
+          return;
+        }
+        setResult(
           PokemonDmgOption.create({
-            ...r,
-            battleState: eff,
+            battleState: data.battleState,
             move,
-            damage: calculateDamagePVE(statLvATK, statLvDEFObj, move.pvePower, eff),
-            hp: statLvSTAObj,
+            damage: data.damage,
+            hp: data.hp,
             currPoke: searchingToolCurrentData?.form,
             objPoke: searchingToolObjectData?.form,
             type: statType,
@@ -203,8 +200,11 @@ const Damage = () => {
             objLevel: statLevelObj,
           })
         );
-      } else {
-        showSnackbar('Please select move for pokémon!', 'error');
+      } catch {
+        clearData();
+        showSnackbar('Damage Simulator API is unavailable.', 'error');
+      } finally {
+        hideSpinner();
       }
     },
     [
@@ -213,13 +213,13 @@ const Damage = () => {
       move,
       searchingToolCurrentData?.form,
       searchingToolObjectData?.form,
-      statLvATK,
-      statLvDEFObj,
-      statLvSTAObj,
       statType,
       statTypeObj,
       statLevel,
       statLevelObj,
+      showSnackbar,
+      showSpinner,
+      hideSpinner,
     ]
   );
 
@@ -236,7 +236,6 @@ const Damage = () => {
         <div className="lg:tw-flex-1 border-window">
           <Find isHide title="Attacker Pokémon" clearStats={clearMove} />
           <StatsDamageTable
-            setStatLvATK={setStatLvATK}
             setStatLevel={setStatLevel}
             setStatType={setStatType}
             statATK={searchingToolCurrentData?.pokemon?.statsGO?.atk}
@@ -248,8 +247,6 @@ const Damage = () => {
         <div className="lg:tw-flex-1 border-window">
           <Find isHide title="Defender Pokémon" isSwap clearStats={clearData} isObjective />
           <StatsDamageTable
-            setStatLvDEF={setStatLvDEFObj}
-            setStatLvSTA={setStatLvSTAObj}
             setStatLevel={setStatLevelObj}
             setStatType={setStatTypeObj}
             statATK={searchingToolObjectData?.pokemon?.statsGO?.atk}

--- a/src/pages/Tools/BattleDamage/StatsDamageTable.tsx
+++ b/src/pages/Tools/BattleDamage/StatsDamageTable.tsx
@@ -1,14 +1,7 @@
 import { Box, FormControlLabel, Radio } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import {
-  LevelSlider,
-  TypeRadioGroup,
-  getDmgMultiplyBonus,
-  getKeyWithData,
-  isSpecialMegaFormType,
-} from '../../../utils/utils';
-import { calculateStatsBattle } from '../../../utils/calculate';
+import { LevelSlider, TypeRadioGroup, getKeyWithData, isSpecialMegaFormType } from '../../../utils/utils';
 
 import APIService from '../../../services/api.service';
 
@@ -16,13 +9,15 @@ import ATK_LOGO from '../../../assets/attack.png';
 import DEF_LOGO from '../../../assets/defense.png';
 import HP_LOGO from '../../../assets/hp.png';
 import { IStatsDamageTableComponent } from '../../models/page.model';
-import { PokemonType, TypeAction } from '../../../enums/type.enum';
+import { PokemonType } from '../../../enums/type.enum';
 import { toNumber } from '../../../utils/extension';
 import { maxIv, minLevel, maxLevel, stepLevel } from '../../../utils/helpers/options-context.helpers';
+import type { DamageCalculatedStats } from '../../../services/models/tools-api.model';
 
 const StatsDamageTable = (props: IStatsDamageTableComponent) => {
   const [currStatLevel, setCurrStatLevel] = useState(1);
   const [currStatType, setCurrStatType] = useState(PokemonType.Normal);
+  const [calculatedStats, setCalculatedStats] = useState<DamageCalculatedStats[]>([]);
 
   useEffect(() => {
     if (props.setStatType && currStatType === PokemonType.Shadow && isSpecialMegaFormType(props.pokemonType)) {
@@ -31,49 +26,42 @@ const StatsDamageTable = (props: IStatsDamageTableComponent) => {
     }
   }, [props.setStatType, currStatType, props.pokemonType]);
 
+  useEffect(() => {
+    if (props.statATK === undefined || props.statDEF === undefined || props.statSTA === undefined) {
+      setCalculatedStats([]);
+      return;
+    }
+    let active = true;
+    APIService.postDamageSimulator({
+      mode: 'stats',
+      base: { atk: props.statATK, def: props.statDEF, sta: props.statSTA },
+      pokemonType: currStatType,
+      iv: maxIv(),
+      config: { minLevel: minLevel(), maxLevel: maxLevel(), step: stepLevel() },
+    })
+      .then((response) => {
+        if (active && response.data.data.mode === 'stats') {
+          setCalculatedStats(response.data.data.levels);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setCalculatedStats([]);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [props.statATK, props.statDEF, props.statSTA, currStatType]);
+
   const onHandleLevel = useCallback(
     (v: number) => {
       if (props.setStatLevel) {
         props.setStatLevel(v);
       }
-      if (props.setStatLvATK) {
-        props.setStatLvATK(
-          calculateStatsBattle(
-            props.statATK,
-            maxIv(),
-            currStatLevel,
-            false,
-            getDmgMultiplyBonus(currStatType, TypeAction.Atk)
-          )
-        );
-      }
-      if (props.setStatLvDEF) {
-        props.setStatLvDEF(
-          calculateStatsBattle(
-            props.statDEF,
-            maxIv(),
-            currStatLevel,
-            false,
-            getDmgMultiplyBonus(currStatType, TypeAction.Def)
-          )
-        );
-      }
-      if (props.setStatLvSTA) {
-        props.setStatLvSTA(calculateStatsBattle(props.statSTA, maxIv(), currStatLevel));
-      }
       setCurrStatLevel(v);
     },
-    [
-      props.setStatLevel,
-      props.setStatLvATK,
-      props.setStatLvDEF,
-      props.setStatLvSTA,
-      props.statATK,
-      props.statDEF,
-      props.statSTA,
-      currStatType,
-      currStatLevel,
-    ]
+    [props.setStatLevel]
   );
 
   const onHandleType = useCallback(
@@ -90,31 +78,9 @@ const StatsDamageTable = (props: IStatsDamageTableComponent) => {
     [props.setStatType, props.setStatLevel]
   );
 
-  const displayATK = useMemo(
-    () =>
-      calculateStatsBattle(
-        props.statATK,
-        maxIv(),
-        currStatLevel,
-        true,
-        getDmgMultiplyBonus(currStatType, TypeAction.Atk)
-      ),
-    [props.statATK, currStatLevel, currStatType]
-  );
-  const displayDEF = useMemo(
-    () =>
-      calculateStatsBattle(
-        props.statDEF,
-        maxIv(),
-        currStatLevel,
-        true,
-        getDmgMultiplyBonus(currStatType, TypeAction.Def)
-      ),
-    [props.statDEF, currStatLevel, currStatType]
-  );
-  const displaySTA = useMemo(
-    () => calculateStatsBattle(props.statSTA, maxIv(), currStatLevel, true),
-    [props.statSTA, currStatLevel]
+  const displayStats = useMemo(
+    () => calculatedStats.find((stats) => stats.level === currStatLevel),
+    [calculatedStats, currStatLevel]
   );
 
   return (
@@ -190,7 +156,7 @@ const StatsDamageTable = (props: IStatsDamageTableComponent) => {
                     <span>ATK</span>
                   </div>
                 </td>
-                <td className="!tw-text-center">{displayATK}</td>
+                <td className="!tw-text-center">{displayStats ? Math.floor(displayStats.atk) : '-'}</td>
               </tr>
               <tr>
                 <td>
@@ -199,7 +165,7 @@ const StatsDamageTable = (props: IStatsDamageTableComponent) => {
                     <span>DEF</span>
                   </div>
                 </td>
-                <td className="!tw-text-center">{displayDEF}</td>
+                <td className="!tw-text-center">{displayStats ? Math.floor(displayStats.def) : '-'}</td>
               </tr>
               <tr>
                 <td>
@@ -208,7 +174,7 @@ const StatsDamageTable = (props: IStatsDamageTableComponent) => {
                     <span>HP</span>
                   </div>
                 </td>
-                <td className="!tw-text-center">{displaySTA}</td>
+                <td className="!tw-text-center">{displayStats ? Math.floor(displayStats.sta) : '-'}</td>
               </tr>
             </tbody>
           </table>

--- a/src/pages/Tools/CalculateStats/CalculateStats.tsx
+++ b/src/pages/Tools/CalculateStats/CalculateStats.tsx
@@ -9,13 +9,6 @@ import {
   splitAndCapitalize,
   TypeRadioGroup,
 } from '../../../utils/utils';
-import {
-  calculateBattleLeague,
-  calculateBetweenLevel,
-  calculateStats,
-  calculateStatsBattle,
-} from '../../../utils/calculate';
-
 import { Box, FormControlLabel, Radio } from '@mui/material';
 
 import APIService from '../../../services/api.service';
@@ -28,7 +21,7 @@ import HP_LOGO from '../../../assets/hp.png';
 import Find from '../../../components/Find/Find';
 import Candy from '../../../components/Sprites/Candy/Candy';
 import CandyXL from '../../../components/Sprites/Candy/CandyXL';
-import { IBattleLeagueCalculate, IBetweenLevelCalculate, IStatsCalculate } from '../../../utils/models/calculate.model';
+import { IBattleLeagueCalculate, IStatsCalculate } from '../../../utils/models/calculate.model';
 import DynamicInputCP from '../../../components/Commons/Inputs/DynamicInputCP';
 import { useTitle } from '../../../utils/hooks/useTitle';
 import { isUndefined, toNumber } from '../../../utils/extension';
@@ -40,6 +33,8 @@ import { minCp, minIv, maxIv, minLevel, maxLevel, stepLevel } from '../../../uti
 import useSearch from '../../../composables/useSearch';
 import ButtonMui from '../../../components/Commons/Buttons/ButtonMui';
 import { useSnackbar } from '../../../contexts/snackbar.context';
+import useSpinner from '../../../composables/useSpinner';
+import type { CalculateStatsLevelResult } from '../../../services/models/tools-api.model';
 
 const Calculate = () => {
   useTitle({
@@ -67,7 +62,8 @@ const Calculate = () => {
 
   const [pokeStats, setPokeStats] = useState<IStatsCalculate>();
   const [statLevel, setStatLevel] = useState(1);
-  const [statData, setStatData] = useState<IBetweenLevelCalculate>();
+  const [statData, setStatData] = useState<CalculateStatsLevelResult>();
+  const [levelResults, setLevelResults] = useState<Array<{ level: number; data: CalculateStatsLevelResult }>>([]);
 
   const [dataLittleLeague, setDataLittleLeague] = useState<IBattleLeagueCalculate>();
   const [dataGreatLeague, setDataGreatLeague] = useState<IBattleLeagueCalculate>();
@@ -75,12 +71,14 @@ const Calculate = () => {
   const [dataMasterLeague, setDataMasterLeague] = useState<IBattleLeagueCalculate>();
 
   const { showSnackbar } = useSnackbar();
+  const { showSpinner, hideSpinner } = useSpinner();
 
   const clearArrStats = () => {
     setSearchCP('');
     setPokeStats(undefined);
     setStatLevel(1);
     setStatData(undefined);
+    setLevelResults([]);
     setATKIv(0);
     setDEFIv(0);
     setSTAIv(0);
@@ -90,87 +88,77 @@ const Calculate = () => {
     setDataMasterLeague(undefined);
   };
 
-  const calculateStatsPoke = useCallback(() => {
+  const calculateStatsPoke = useCallback(async () => {
     if (toNumber(searchCP) < minCp()) {
       showSnackbar(`Please input CP greater than or equal to ${minCp()}`, 'error');
       return;
     }
-    const statATK = toNumber(searchingToolCurrentDetails?.statsGO?.atk);
-    const statDEF = toNumber(searchingToolCurrentDetails?.statsGO?.def);
-    const statSTA = toNumber(searchingToolCurrentDetails?.statsGO?.sta);
+    const pokemonId = toNumber(searchingToolCurrentDetails?.id);
     const name = splitAndCapitalize(searchingToolCurrentDetails?.fullName, '_', ' ');
-    const result = calculateStats(statATK, statDEF, statSTA, ATKIv, DEFIv, STAIv, searchCP);
-    if (!result.level) {
-      showSnackbar(
-        `At CP: ${result.CP} and IV ${result.IV.atkIV}/${result.IV.defIV}/${result.IV.staIV} impossible found in ${name}`,
-        'error'
-      );
+    if (!pokemonId) {
+      showSnackbar('Please select a Pokémon before calculating stats', 'error');
       return;
     }
-    showSnackbar(
-      `At CP: ${result.CP} and IV ${result.IV.atkIV}/${result.IV.defIV}/${result.IV.staIV} found in ${typePoke} ${name}`,
-      'success'
-    );
-    setPokeStats(result);
-    setStatLevel(result.level);
-    setStatData(
-      calculateBetweenLevel(statATK, statDEF, statSTA, ATKIv, DEFIv, STAIv, result.level, result.level, typePoke)
-    );
-    setDataLittleLeague(
-      calculateBattleLeague(
-        statATK,
-        statDEF,
-        statSTA,
-        ATKIv,
-        DEFIv,
-        STAIv,
-        result.level,
-        result.CP,
-        typePoke,
-        BattleLeagueCPType.Little
-      )
-    );
-    setDataGreatLeague(
-      calculateBattleLeague(
-        statATK,
-        statDEF,
-        statSTA,
-        ATKIv,
-        DEFIv,
-        STAIv,
-        result.level,
-        result.CP,
-        typePoke,
-        BattleLeagueCPType.Great
-      )
-    );
-    setDataUltraLeague(
-      calculateBattleLeague(
-        statATK,
-        statDEF,
-        statSTA,
-        ATKIv,
-        DEFIv,
-        STAIv,
-        result.level,
-        result.CP,
-        typePoke,
-        BattleLeagueCPType.Ultra
-      )
-    );
-    setDataMasterLeague(
-      calculateBattleLeague(statATK, statDEF, statSTA, ATKIv, DEFIv, STAIv, result.level, result.CP, typePoke)
-    );
+    showSpinner();
+    try {
+      const response = await APIService.postCalculateStats({
+        id: pokemonId,
+        form: searchingToolCurrentDetails?.fullName,
+        cp: toNumber(searchCP),
+        pokemonType: typePoke,
+        iv: { atk: ATKIv, def: DEFIv, sta: STAIv },
+        config: { minCp: minCp(), minLevel: minLevel(), maxLevel: maxLevel(), step: stepLevel() },
+      });
+      const result = response.data.data;
+      if (!result.possible) {
+        setPokeStats(undefined);
+        setStatData(undefined);
+        setLevelResults([]);
+        setDataLittleLeague(undefined);
+        setDataGreatLeague(undefined);
+        setDataUltraLeague(undefined);
+        setDataMasterLeague(undefined);
+        showSnackbar(
+          `At CP: ${result.stats.CP} and IV ${result.stats.IV.atkIV}/${result.stats.IV.defIV}/${result.stats.IV.staIV} impossible found in ${name}`,
+          'error'
+        );
+        return;
+      }
+      showSnackbar(
+        `At CP: ${result.stats.CP} and IV ${result.stats.IV.atkIV}/${result.stats.IV.defIV}/${result.stats.IV.staIV} found in ${typePoke} ${name}`,
+        'success'
+      );
+      setPokeStats(result.stats);
+      setStatLevel(result.stats.level);
+      setStatData(result.current);
+      setLevelResults(result.levels);
+      setDataLittleLeague(result.leagues.little);
+      setDataGreatLeague(result.leagues.great);
+      setDataUltraLeague(result.leagues.ultra);
+      setDataMasterLeague(result.leagues.master);
+    } catch {
+      setPokeStats(undefined);
+      setStatData(undefined);
+      setLevelResults([]);
+      setDataLittleLeague(undefined);
+      setDataGreatLeague(undefined);
+      setDataUltraLeague(undefined);
+      setDataMasterLeague(undefined);
+      showSnackbar('Calculate Stats API is unavailable', 'error');
+    } finally {
+      hideSpinner();
+    }
   }, [
-    searchingToolCurrentDetails?.statsGO?.atk,
-    searchingToolCurrentDetails?.statsGO?.def,
-    searchingToolCurrentDetails?.statsGO?.sta,
+    searchingToolCurrentDetails?.id,
     ATKIv,
     DEFIv,
     STAIv,
     searchCP,
     searchingToolCurrentDetails?.fullName,
     typePoke,
+    showSnackbar,
+    showSpinner,
+    hideSpinner,
   ]);
 
   const onCalculateStatsPoke = useCallback(
@@ -182,14 +170,10 @@ const Calculate = () => {
   );
 
   const onHandleLevel = (level: number) => {
-    if (pokeStats) {
+    const result = levelResults.find((item) => item.level === level)?.data;
+    if (pokeStats && result) {
       setStatLevel(level);
-      const statATK = toNumber(searchingToolCurrentDetails?.statsGO?.atk);
-      const statDEF = toNumber(searchingToolCurrentDetails?.statsGO?.def);
-      const statSTA = toNumber(searchingToolCurrentDetails?.statsGO?.sta);
-      setStatData(
-        calculateBetweenLevel(statATK, statDEF, statSTA, ATKIv, DEFIv, STAIv, pokeStats.level, level, typePoke)
-      );
+      setStatData(result);
     }
   };
 
@@ -406,6 +390,7 @@ const Calculate = () => {
               onChange={(e) => {
                 setPokeStats(undefined);
                 setStatData(undefined);
+                setLevelResults([]);
                 setStatLevel(0);
                 setDataLittleLeague(undefined);
                 setDataGreatLeague(undefined);
@@ -640,12 +625,7 @@ const Calculate = () => {
                         <td>
                           {statData ? (
                             statData.pokemonType !== PokemonType.Shadow ? (
-                              calculateStatsBattle(
-                                toNumber(searchingToolCurrentDetails?.statsGO?.atk),
-                                pokeStats?.IV.atkIV,
-                                statLevel,
-                                true
-                              )
+                              statData.stats.atk
                             ) : (
                               <Fragment>
                                 {statData.atkStat}
@@ -669,12 +649,7 @@ const Calculate = () => {
                         <td>
                           {statData ? (
                             statData.pokemonType !== PokemonType.Shadow ? (
-                              calculateStatsBattle(
-                                toNumber(searchingToolCurrentDetails?.statsGO?.def),
-                                pokeStats?.IV.defIV,
-                                statLevel,
-                                true
-                              )
+                              statData.stats.def
                             ) : (
                               <Fragment>
                                 {statData.defStat}
@@ -695,16 +670,7 @@ const Calculate = () => {
                             <span>HP</span>
                           </div>
                         </td>
-                        <td>
-                          {statData
-                            ? calculateStatsBattle(
-                                toNumber(searchingToolCurrentDetails?.statsGO?.sta),
-                                pokeStats?.IV.staIV,
-                                statLevel,
-                                true
-                              )
-                            : '-'}
-                        </td>
+                        <td>{statData ? statData.stats.sta : '-'}</td>
                       </tr>
                     </tbody>
                   </table>

--- a/src/pages/Tools/RaidBattle/RaidBattle.tsx
+++ b/src/pages/Tools/RaidBattle/RaidBattle.tsx
@@ -13,14 +13,6 @@ import {
   splitAndCapitalize,
 } from '../../../utils/utils';
 import { RAID_BOSS_TIER } from '../../../utils/constants';
-import {
-  calculateBattleDPS,
-  calculateBattleDPSDefender,
-  calculateStatsBattle,
-  calculateStatsByTag,
-  TimeToKill,
-} from '../../../utils/calculate';
-
 import { Badge, Checkbox, FormControlLabel, IconButton, LinearProgress, Switch } from '@mui/material';
 
 import './RaidBattle.scss';
@@ -45,8 +37,6 @@ import {
   IPokemonRaidModel,
   PokemonData,
   PokemonDataStats,
-  PokemonDPSBattle,
-  PokemonMoveData,
   PokemonRaidModel,
 } from '../../../core/models/pokemon.model';
 import {
@@ -56,11 +46,8 @@ import {
 } from '../../../components/Commons/Inputs/models/select-move.model';
 import { MoveType, PokemonType, TypeMove } from '../../../enums/type.enum';
 import { useTitle } from '../../../utils/hooks/useTitle';
-import { BattleCalculate } from '../../../utils/models/calculate.model';
 import {
   combineClasses,
-  DynamicObj,
-  getPropertyName,
   getValueOrDefault,
   isNotEmpty,
   toFloat,
@@ -72,9 +59,7 @@ import {
   MovePokemon,
   IRaidResult,
   ITrainerBattle,
-  RaidResult,
   RaidSetting,
-  RaidSummary,
   TrainerBattle,
   Filter,
   FilterGroup,
@@ -90,7 +75,6 @@ import { defaultPokemonLevel, maxIv, minIv } from '../../../utils/helpers/option
 import useAssets from '../../../composables/useAssets';
 import useSpinner from '../../../composables/useSpinner';
 import usePokemon from '../../../composables/usePokemon';
-import useCombats from '../../../composables/useCombats';
 import useSearch from '../../../composables/useSearch';
 import { getLevelList } from '../../../utils/compute';
 import InputMui from '../../../components/Commons/Inputs/InputMui';
@@ -100,7 +84,7 @@ import ButtonMui from '../../../components/Commons/Buttons/ButtonMui';
 import { useSnackbar } from '../../../contexts/snackbar.context';
 import DialogMui from '../../../components/Commons/Dialogs/Dialogs';
 import Tooltips from '../../../components/Commons/Tooltips/Tooltips';
-import type { RaidApiResponse } from '../../../services/models/tools-api.model';
+import type { RaidApiResponse, RaidBattleRequest } from '../../../services/models/tools-api.model';
 
 const SORT_MENU_ITEMS = [
   { value: SortType.DPS, label: 'Damage Per Second' },
@@ -129,10 +113,9 @@ const RaidBattle = () => {
     ],
   });
   const { getFilteredPokemons } = usePokemon();
-  const { findMoveByName } = useCombats();
   const { getAssetNameById } = useAssets();
   const { showSpinner, hideSpinner } = useSpinner();
-  const { retrieveMoves, checkPokemonGO } = usePokemon();
+  const { retrieveMoves } = usePokemon();
   const { searchingToolCurrentData } = useSearch();
 
   const [statBossATK, setStatBossATK] = useState(0);
@@ -230,30 +213,11 @@ const RaidBattle = () => {
     );
   };
 
-  const setSortedResult = (primary: IPokemonMoveData, secondary: IPokemonMoveData) => {
-    const type = getPropertyName(primary || secondary, (r) =>
-      filters.selected.sortBy === SortType.TDO
-        ? r.tdoAtk
-        : filters.selected.sortBy === SortType.TTK
-          ? r.ttkAtk
-          : filters.selected.sortBy === SortType.TANK
-            ? r.ttkDef
-            : r.dpsAtk
-    );
-    const a = primary as unknown as DynamicObj<SortType>;
-    const b = secondary as unknown as DynamicObj<SortType>;
-    return filters.selected.sorted ? a[type] - b[type] : b[type] - a[type];
-  };
-
   const handleSaveOption = () => {
     if (isInvalidIV(selected.iv.atkIV) || isInvalidIV(selected.iv.defIV) || isInvalidIV(selected.iv.staIV)) {
       return;
     }
-    const changeResult =
-      selected.level !== used.level ||
-      selected.iv.atkIV !== used.iv.atkIV ||
-      selected.iv.defIV !== used.iv.defIV ||
-      selected.iv.staIV !== used.iv.staIV;
+    const changeResult = JSON.stringify(selected) !== JSON.stringify(used);
     setFilters({
       ...filters,
       used: selected,
@@ -261,9 +225,8 @@ const RaidBattle = () => {
     setShowOption(false);
 
     if (changeResult) {
-      handleCalculate();
+      void handleCalculate(true, selected);
     }
-    setResult(result.sort((a, b) => setSortedResult(a, b)));
   };
 
   const handleCloseOption = () => {
@@ -358,23 +321,37 @@ const RaidBattle = () => {
     }
   };
 
-  const calculateBossBattle = async () => {
+  const calculateBossBattle = async (filter = used, hideWhenDone = true) => {
+    const sort =
+      filter.sortBy === SortType.TDO
+        ? 'tdo'
+        : filter.sortBy === SortType.TTK
+          ? 'ttkAtk'
+          : filter.sortBy === SortType.TANK
+            ? 'ttkDef'
+            : 'dps';
+    const lowerIsBetter = sort === 'ttkAtk';
+    const showWorst = filter.sorted === SortDirectionType.DESC;
+    const order = showWorst === lowerIsBetter ? 'desc' : 'asc';
+
     try {
       const response = await APIService.getFetchUrl<RaidApiResponse>(
         APIService.getDpsTdo({
           raid: true,
           best: true,
-          bestBy: 'dps',
-          sort: 'dps',
-          order: 'desc',
+          bestBy: sort,
+          sort,
+          order,
           page: 1,
-          limit: 250,
-          released: false,
+          limit: 10,
+          released: filter.onlyReleasedGO,
+          enableShadow: filter.onlyShadow || undefined,
+          enableMega: filter.onlyMega || undefined,
           showGMax: false,
-          ivAtk: used.iv.atkIV,
-          ivDef: used.iv.defIV,
-          ivHp: used.iv.staIV,
-          level: used.level,
+          ivAtk: filter.iv.atkIV,
+          ivDef: filter.iv.defIV,
+          ivHp: filter.iv.staIV,
+          level: filter.level,
           targetId: searchingToolCurrentData?.form?.defaultId,
           targetForm: searchingToolCurrentData?.pokemon?.fullName,
           targetFast: fMove?.name,
@@ -388,173 +365,43 @@ const RaidBattle = () => {
         })
       );
       const summary = response.data.meta.raidSummary;
-      if (!summary?.dps || !summary.tdo || !summary.hp) {
+      if (!summary?.dps || !summary.tdo || !summary.hp || !summary.suggestedPlayers) {
         throw new Error('invalid_raid_summary');
       }
       setResult(response.data.data);
       setResultBoss({
         minDPS: summary.dps.min,
         maxDPS: summary.dps.max,
+        averageDPS: summary.dps.average,
         minTDO: summary.tdo.min,
         maxTDO: summary.tdo.max,
+        averageTDO: summary.tdo.average,
         minHP: summary.hp.min,
         maxHP: summary.hp.max,
+        averageHP: summary.hp.average,
+        hardPlayers: summary.suggestedPlayers.hard,
+        easyPlayers: summary.suggestedPlayers.easy,
       });
       setDisableSearch(true);
     } catch {
       showSnackbar('Raid Battle API is unavailable.', 'error');
     } finally {
-      hideSpinner();
-    }
-  };
-
-  const calculateDPSBattle = (pokemonRaid: IPokemonRaidModel, hpRemain: number, timer: number) => {
-    const fMoveCurrent = findMoveByName(pokemonRaid.fMoveTargetPokemon?.name);
-    const cMoveCurrent = findMoveByName(pokemonRaid.cMoveTargetPokemon?.name);
-
-    if (fMoveCurrent && cMoveCurrent) {
-      const fMoveWithType = { ...fMoveCurrent, moveType: pokemonRaid.fMoveTargetPokemon?.moveType };
-      const cMoveWithType = { ...cMoveCurrent, moveType: pokemonRaid.cMoveTargetPokemon?.moveType };
-      const stats = calculateStatsByTag(
-        pokemonRaid.dataTargetPokemon,
-        pokemonRaid.dataTargetPokemon?.baseStats,
-        pokemonRaid.dataTargetPokemon?.slug
-      );
-      const statsGO = pokemonRaid.dataTargetPokemon?.stats ?? used;
-      const statsAttacker = new BattleCalculate({
-        atk: calculateStatsBattle(stats.atk, statsGO.iv.atkIV, statsGO.level),
-        def: calculateStatsBattle(stats.def, statsGO.iv.defIV, statsGO.level),
-        hp: calculateStatsBattle(stats?.sta, statsGO.iv.staIV, statsGO.level),
-        fMove: fMoveWithType,
-        cMove: cMoveWithType,
-        types: pokemonRaid.dataTargetPokemon?.types,
-        pokemonType: statsGO.pokemonType,
-      });
-      const statsDefender = new BattleCalculate({
-        atk: statBossATK,
-        def: statBossDEF,
-        hp: Math.floor(hpRemain),
-        fMove: findMoveByName(fMove?.name),
-        cMove: findMoveByName(cMove?.name),
-        types: searchingToolCurrentData?.form?.form?.types,
-        isStab: isWeatherBoss,
-      });
-
-      const dpsDef = calculateBattleDPSDefender(statsAttacker, statsDefender);
-      const dpsAtk = calculateBattleDPS(statsAttacker, statsDefender, dpsDef);
-
-      const ttkAtk = enableTimeAllow
-        ? Math.min(timeAllow - timer, TimeToKill(Math.floor(toNumber(statsDefender.hp)), dpsAtk))
-        : TimeToKill(Math.floor(toNumber(statsDefender.hp)), dpsAtk);
-      const ttkDef = enableTimeAllow
-        ? Math.min(timeAllow - timer, TimeToKill(Math.floor(toNumber(statsAttacker.hp)), dpsDef))
-        : TimeToKill(Math.floor(toNumber(statsAttacker.hp)), dpsDef);
-
-      const timeKill = Math.min(ttkAtk, ttkDef);
-
-      const tdoAtk = dpsAtk * (enableTimeAllow ? timeKill : ttkDef);
-      const tdoDef = dpsDef * (enableTimeAllow ? timeKill : ttkAtk);
-
-      return PokemonDPSBattle.create({
-        pokemon: pokemonRaid.dataTargetPokemon,
-        fMove: statsAttacker.fMove,
-        cMove: statsAttacker.cMove,
-        atk: statsAttacker.atk,
-        def: statsAttacker.def,
-        hp: statsAttacker.hp,
-        dpsAtk,
-        dpsDef,
-        tdoAtk,
-        tdoDef,
-        ttkAtk,
-        ttkDef,
-        timer: timeKill,
-        defHpRemain: Math.floor(toNumber(statsDefender.hp)) - tdoAtk,
-      });
+      if (hideWhenDone) {
+        hideSpinner();
+      }
     }
   };
 
   const disableRaidBattle = (trainerBattle: ITrainerBattle[]) => {
     const trainer = trainerBattle.map((trainer) => trainer.pokemons);
-    const trainerNoPokemon = trainer.filter((pokemon) => isNotEmpty(pokemon.filter((item) => !item.dataTargetPokemon)));
+    const trainerNoPokemon = trainer.filter((pokemon) =>
+      isNotEmpty(
+        pokemon.filter(
+          (item) => !item.dataTargetPokemon || !item.fMoveTargetPokemon?.name || !item.cMoveTargetPokemon?.name
+        )
+      )
+    );
     return isNotEmpty(trainerNoPokemon);
-  };
-
-  const runTrainerBattle = (trainerBattle: ITrainerBattle[], bossHpInit: number) => {
-    const trainer = trainerBattle.map((t) => t.pokemons);
-    const turn: IPokemonRaidModel[][] = [];
-    trainer.forEach((pokemons, trainerId) => {
-      pokemons.forEach((_, index) => {
-        turn[index] ??= [];
-        turn[index].push(PokemonRaidModel.create({ ...trainer[trainerId][index], trainerId }));
-      });
-    });
-    const result: IRaidResult[] = [];
-    let timer = 0,
-      bossHp = bossHpInit;
-    turn.forEach((group) => {
-      const dataList = new RaidResult({
-        pokemon: [],
-        summary: RaidSummary.create({
-          dpsAtk: 0,
-          dpsDef: 0,
-          tdoAtk: 0,
-          tdoDef: 0,
-          timer,
-          bossHp: Math.max(0, bossHp),
-        }),
-      });
-      group.forEach((pokemon) => {
-        if (pokemon.dataTargetPokemon) {
-          const stat = calculateDPSBattle(pokemon, dataList.summary.bossHp, timer);
-          if (stat) {
-            dataList.pokemon.push({ ...stat, trainerId: toNumber(pokemon.trainerId) });
-          }
-
-          if (enableTimeAllow) {
-            dataList.summary.timer = Math.min(timeAllow, dataList.summary.timer);
-          }
-        }
-      });
-
-      dataList.summary.tdoAtk = Math.min(
-        dataList.summary.bossHp,
-        dataList.pokemon.reduce((prev, curr) => prev + curr.tdoAtk, 0)
-      );
-      dataList.summary.dpsAtk = dataList.pokemon.reduce((prev, curr) => prev + curr.dpsAtk, 0);
-      dataList.summary.tdoDef = dataList.pokemon.reduce((prev, curr) => prev + curr.tdoDef, 0);
-      dataList.summary.dpsDef = dataList.pokemon.reduce((prev, curr) => prev + curr.dpsDef, 0);
-
-      const sumHp = dataList.pokemon.reduce((prev, curr) => prev + toNumber(curr.hp), 0);
-
-      const ttkAtk = enableTimeAllow
-        ? Math.min(timeAllow - timer, TimeToKill(Math.floor(dataList.summary.bossHp), dataList.summary.dpsAtk))
-        : TimeToKill(Math.floor(dataList.summary.bossHp), dataList.summary.dpsAtk);
-      const ttkDef = enableTimeAllow
-        ? Math.min(timeAllow - timer, TimeToKill(Math.floor(sumHp), dataList.summary.dpsDef))
-        : TimeToKill(Math.floor(sumHp), dataList.summary.dpsDef);
-      const timeKill = Math.min(ttkAtk, ttkDef);
-
-      const bossKilled = dataList.summary.tdoAtk >= Math.floor(dataList.summary.bossHp);
-      bossHp -= dataList.summary.tdoAtk;
-      timer += timeKill;
-      dataList.summary.timer = timer;
-
-      dataList.pokemon = dataList.pokemon.map((pokemon) => {
-        const tdoAtk = (dataList.summary.tdoAtk / dataList.summary.dpsAtk) * pokemon.dpsAtk;
-        const ttkDefPokemon = toNumber(timeKill, pokemon.ttkDef);
-        return PokemonMoveData.create({
-          ...pokemon,
-          tdoAtk,
-          atkHpRemain: bossKilled
-            ? Math.max(0, Math.floor(toNumber(pokemon.hp)) - Math.min(ttkDefPokemon, timeKill) * pokemon.dpsDef)
-            : Math.max(0, Math.floor(toNumber(pokemon.hp)) - Math.max(ttkDefPokemon, timeKill) * pokemon.dpsDef),
-        });
-      });
-      result.push(dataList);
-    });
-    setResultRaid(result);
-    showSnackbar('Simulator battle raid successfully!', 'success');
   };
 
   const calculateTrainerBattle = async (trainerBattle: ITrainerBattle[]) => {
@@ -562,13 +409,61 @@ const RaidBattle = () => {
       showSnackbar('Please select Pokémon to raid battle!', 'error');
       return;
     }
-    if (!resultBoss) {
-      showSpinner();
-      clearDataBoss(false);
-      await calculateBossBattle();
-      runTrainerBattle(trainerBattle, statBossHP);
-    } else {
-      runTrainerBattle(trainerBattle, statBossHP);
+    const bossId = searchingToolCurrentData?.form?.defaultId;
+    if (!bossId || !fMove?.name || !cMove?.name) {
+      showSnackbar('Please select raid boss moves!', 'error');
+      return;
+    }
+
+    const payload: RaidBattleRequest = {
+      boss: {
+        id: bossId,
+        form: searchingToolCurrentData?.pokemon?.fullName,
+        fast: fMove.name,
+        charged: cMove.name,
+        atk: statBossATK,
+        def: statBossDEF,
+        hp: statBossHP,
+        boost: isWeatherBoss,
+      },
+      settings: {
+        timeAllow,
+        enableTimeAllow,
+        counterBoost: options.isWeatherCounter,
+      },
+      trainers: trainerBattle.map((trainer) => ({
+        trainerId: trainer.trainerId,
+        pokemons: trainer.pokemons.map((selected) => {
+          const pokemon = selected.dataTargetPokemon;
+          const stats = pokemon?.stats ?? used;
+          return {
+            id: toNumber(pokemon?.num),
+            form: pokemon?.fullName,
+            fast: getValueOrDefault(String, selected.fMoveTargetPokemon?.name),
+            charged: getValueOrDefault(String, selected.cMoveTargetPokemon?.name),
+            level: stats.level,
+            pokemonType: stats.pokemonType,
+            iv: { atk: stats.iv.atkIV, def: stats.iv.defIV, hp: stats.iv.staIV },
+            fMoveType: selected.fMoveTargetPokemon?.moveType,
+            cMoveType: selected.cMoveTargetPokemon?.moveType,
+          };
+        }),
+      })),
+    };
+
+    showSpinner();
+    try {
+      if (!resultBoss) {
+        clearDataBoss(false);
+        await calculateBossBattle(used, false);
+      }
+      const response = await APIService.postRaidBattle(payload);
+      setResultRaid(response.data.data);
+      showSnackbar('Simulator battle raid successfully!', 'success');
+    } catch {
+      showSnackbar('Raid Battle simulation API is unavailable.', 'error');
+    } finally {
+      hideSpinner();
     }
   };
 
@@ -594,10 +489,10 @@ const RaidBattle = () => {
     setDisableSearch(false);
   }, [options.enableTimeAllow, options.isReleased, options.isWeatherBoss, options.isWeatherCounter, timeAllow]);
 
-  const handleCalculate = async (isClear = true) => {
+  const handleCalculate = async (isClear = true, filter = used) => {
     showSpinner();
     clearDataBoss(isClear);
-    await calculateBossBattle();
+    await calculateBossBattle(filter);
   };
 
   const calculateHpBar = (bossHp: number, tdo: number, sumDps: number) => {
@@ -641,9 +536,6 @@ const RaidBattle = () => {
       </Fragment>
     );
   };
-
-  const calcSuggestedPlayers = (bossHp: number, tdoPerPokemon: number) =>
-    Math.max(1, Math.ceil(bossHp / (tdoPerPokemon * 6)));
 
   const resultBattle = (bossHp: number, timer: number) => {
     const status =
@@ -1345,74 +1237,51 @@ const RaidBattle = () => {
         </div>
         {isNotEmpty(result) && (
           <div className="top-raid-group">
-            {result
-              .filter((obj) => {
-                if (used.onlyReleasedGO) {
-                  if (!obj.pokemon) {
-                    return false;
-                  }
-                  const isReleasedGO = checkPokemonGO(
-                    obj.pokemon.num,
-                    getValueOrDefault(String, obj.pokemon.fullName, obj.pokemon.pokemonId?.toString())
-                  );
-                  if (!getValueOrDefault(Boolean, obj.pokemon.releasedGO, isReleasedGO)) {
-                    return false;
-                  }
-                }
-                if (used.onlyMega && obj.pokemon?.pokemonType !== PokemonType.Mega) {
-                  return false;
-                }
-                if (used.onlyShadow && obj.pokemonType !== PokemonType.Shadow) {
-                  return false;
-                }
-                return true;
-              })
-              .slice(0, 10)
-              .map((value, index) => (
-                <div className="tw-relative top-raid-pokemon" key={index}>
-                  <div>
-                    <IconButton
-                      color="success"
-                      className="tw-absolute !tw-p-0"
-                      onClick={() => handleShowMovePokemon(value)}
-                    >
-                      <AddCircleIcon fontSize="large" />
-                    </IconButton>
-                  </div>
-                  <div className="tw-flex tw-flex-col tw-gap-2">
-                    <div className="tw-flex tw-justify-center tw-w-full">{renderPokemon(value)}</div>
-                    <span className="tw-flex tw-justify-center tw-gap-2 tw-font-bold tw-w-full">
-                      <span>#{value.pokemon?.num}</span>
-                      <span>{splitAndCapitalize(value.pokemon?.name, '-', ' ')}</span>
-                    </span>
-                    <span className="tw-flex tw-gap-2">
-                      <span>DPS:</span>
-                      <b>{toFloatWithPadding(value.dpsAtk, 2)}</b>
-                    </span>
-                    <span className="tw-flex tw-gap-2">
-                      <span>Total Damage Output:</span>
-                      <b>{toFloatWithPadding(value.tdoAtk, 2)}</b>
-                    </span>
-                    <span className="tw-flex tw-gap-2">
-                      <span>Death:</span>
-                      <b className={value.death === 0 ? '!tw-text-green-600' : '!tw-text-red-600'}>{value.death}</b>
-                    </span>
-                    <span className="tw-flex tw-gap-2">
-                      <span>Time to Kill (Boss):</span>
-                      <b>{toFloatWithPadding(value.ttkAtk, 2)} sec</b>
-                    </span>
-                    <span className="tw-flex tw-gap-2">
-                      <span>Time is Killed:</span>
-                      <b>{toFloatWithPadding(value.ttkDef, 2)} sec</b>
-                    </span>
-                  </div>
-                  <hr />
-                  <div className="tw-mb-3">
-                    <TypeBadge title="Fast Move" move={value.fMove} moveType={value.fMoveType ?? MoveType.None} />
-                    <TypeBadge title="Charged Move" move={value.cMove} moveType={value.cMoveType ?? MoveType.None} />
-                  </div>
+            {result.map((value, index) => (
+              <div className="tw-relative top-raid-pokemon" key={index}>
+                <div>
+                  <IconButton
+                    color="success"
+                    className="tw-absolute !tw-p-0"
+                    onClick={() => handleShowMovePokemon(value)}
+                  >
+                    <AddCircleIcon fontSize="large" />
+                  </IconButton>
                 </div>
-              ))}
+                <div className="tw-flex tw-flex-col tw-gap-2">
+                  <div className="tw-flex tw-justify-center tw-w-full">{renderPokemon(value)}</div>
+                  <span className="tw-flex tw-justify-center tw-gap-2 tw-font-bold tw-w-full">
+                    <span>#{value.pokemon?.num}</span>
+                    <span>{splitAndCapitalize(value.pokemon?.name, '-', ' ')}</span>
+                  </span>
+                  <span className="tw-flex tw-gap-2">
+                    <span>DPS:</span>
+                    <b>{toFloatWithPadding(value.dpsAtk, 2)}</b>
+                  </span>
+                  <span className="tw-flex tw-gap-2">
+                    <span>Total Damage Output:</span>
+                    <b>{toFloatWithPadding(value.tdoAtk, 2)}</b>
+                  </span>
+                  <span className="tw-flex tw-gap-2">
+                    <span>Death:</span>
+                    <b className={value.death === 0 ? '!tw-text-green-600' : '!tw-text-red-600'}>{value.death}</b>
+                  </span>
+                  <span className="tw-flex tw-gap-2">
+                    <span>Time to Kill (Boss):</span>
+                    <b>{toFloatWithPadding(value.ttkAtk, 2)} sec</b>
+                  </span>
+                  <span className="tw-flex tw-gap-2">
+                    <span>Time is Killed:</span>
+                    <b>{toFloatWithPadding(value.ttkDef, 2)} sec</b>
+                  </span>
+                </div>
+                <hr />
+                <div className="tw-mb-3">
+                  <TypeBadge title="Fast Move" move={value.fMove} moveType={value.fMoveType ?? MoveType.None} />
+                  <TypeBadge title="Charged Move" move={value.cMove} moveType={value.cMoveType ?? MoveType.None} />
+                </div>
+              </div>
+            ))}
           </div>
         )}
         <div className="row tw-mt-5 tw-mb-2 tw-mx-0">
@@ -1554,7 +1423,7 @@ const RaidBattle = () => {
                     </span>
                     <span className="tw-flex tw-gap-2">
                       <span>Average DPS:</span>
-                      <b>{toFloatWithPadding((resultBoss.minDPS + resultBoss.maxDPS) / 2, 2)}</b>
+                      <b>{toFloatWithPadding(resultBoss.averageDPS, 2)}</b>
                     </span>
                     <span className="tw-flex tw-gap-2 tw-flex-col">
                       <span>Total Damage Output:</span>
@@ -1564,7 +1433,7 @@ const RaidBattle = () => {
                     </span>
                     <span className="tw-flex tw-gap-2">
                       <span>Average Total Damage Output:</span>
-                      <b>{toFloatWithPadding((resultBoss.minTDO + resultBoss.maxTDO) / 2, 2)}</b>
+                      <b>{toFloatWithPadding(resultBoss.averageTDO, 2)}</b>
                     </span>
                     <span className="tw-flex tw-gap-2">
                       <span>Boss HP Remaining:</span>
@@ -1574,29 +1443,23 @@ const RaidBattle = () => {
                     </span>
                     <span className="tw-flex tw-gap-2">
                       <span>Boss Average HP Remaining:</span>
-                      <b>{Math.round((resultBoss.minHP + resultBoss.maxHP) / 2)}</b>
+                      <b>{Math.round(resultBoss.averageHP)}</b>
                     </span>
                   </div>
                   <div className="lg:tw-w-1/2 tw-flex tw-flex-wrap tw-justify-center tw-items-center tw-mb-3">
                     <h2 className="tw-text-center !tw-m-0">Suggested players</h2>
                     <hr className="tw-w-full" />
-                    {(() => {
-                      const hardPlayers = calcSuggestedPlayers(statBossHP, resultBoss.maxTDO);
-                      const easyPlayers = calcSuggestedPlayers(statBossHP, resultBoss.minTDO);
-                      return (
-                        <div className="tw-flex tw-items-center tw-gap-3">
-                          <div className="tw-inline-block tw-text-center">
-                            <h3 className="tw-block !tw-m-0">{hardPlayers}</h3>
-                            <span className="caption !tw-text-red-600">Hard</span>
-                          </div>
-                          <h3 className="!tw-m-0">–</h3>
-                          <div className="tw-inline-block tw-text-center">
-                            <h3 className="tw-block !tw-m-0">{easyPlayers}</h3>
-                            <span className="caption !tw-text-green-600">Easy</span>
-                          </div>
-                        </div>
-                      );
-                    })()}
+                    <div className="tw-flex tw-items-center tw-gap-3">
+                      <div className="tw-inline-block tw-text-center">
+                        <h3 className="tw-block !tw-m-0">{resultBoss.hardPlayers}</h3>
+                        <span className="caption !tw-text-red-600">Hard</span>
+                      </div>
+                      <h3 className="!tw-m-0">–</h3>
+                      <div className="tw-inline-block tw-text-center">
+                        <h3 className="tw-block !tw-m-0">{resultBoss.easyPlayers}</h3>
+                        <span className="caption !tw-text-green-600">Easy</span>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </Fragment>

--- a/src/pages/Tools/RaidBattle/models/raid-battle.model.ts
+++ b/src/pages/Tools/RaidBattle/models/raid-battle.model.ts
@@ -1,9 +1,4 @@
-import {
-  PokemonRaidModel,
-  PokemonMoveData,
-  IPokemonData,
-  IPokemonMoveData,
-} from '../../../../core/models/pokemon.model';
+import { PokemonRaidModel, IPokemonData, IPokemonMoveData } from '../../../../core/models/pokemon.model';
 import { IStatsIV, StatsIV } from '../../../../core/models/stats.model';
 import { PokemonType } from '../../../../enums/type.enum';
 import { minLevel } from '../../../../utils/helpers/options-context.helpers';
@@ -29,10 +24,15 @@ export class TrainerBattle implements ITrainerBattle {
 export interface BattleResult {
   minDPS: number;
   maxDPS: number;
+  averageDPS: number;
   minTDO: number;
   maxTDO: number;
+  averageTDO: number;
   minHP: number;
   maxHP: number;
+  averageHP: number;
+  hardPlayers: number;
+  easyPlayers: number;
 }
 
 interface IRaidSummary {
@@ -60,12 +60,12 @@ export class RaidSummary implements IRaidSummary {
 }
 
 export interface IRaidResult {
-  pokemon: PokemonMoveData[];
+  pokemon: IPokemonMoveData[];
   summary: RaidSummary;
 }
 
 export class RaidResult implements IRaidResult {
-  pokemon: PokemonMoveData[] = [];
+  pokemon: IPokemonMoveData[] = [];
   summary = new RaidSummary();
 
   constructor({ ...props }: IRaidResult) {

--- a/src/pages/Tools/SearchBattle/SearchBattle.tsx
+++ b/src/pages/Tools/SearchBattle/SearchBattle.tsx
@@ -7,42 +7,18 @@ import CloseIcon from '@mui/icons-material/Close';
 import './SearchBattle.scss';
 import APIService from '../../../services/api.service';
 
-import {
-  capitalize,
-  convertPokemonAPIDataName,
-  generateParamForm,
-  getValidPokemonImgPath,
-  splitAndCapitalize,
-} from '../../../utils/utils';
-import { calculateBetweenLevel, calculateStats, calculateStatsByTag } from '../../../utils/calculate';
+import { capitalize, generateParamForm, getValidPokemonImgPath, splitAndCapitalize } from '../../../utils/utils';
 
 import { marks, PokeGoSlider } from '../../../utils/utils';
 import Candy from '../../../components/Sprites/Candy/Candy';
 import CandyXL from '../../../components/Sprites/Candy/CandyXL';
-import { IEvolution } from '../../../core/models/evolution.model';
-import {
-  BattleBaseStats,
-  IBattleBaseStats,
-  IQueryStatesEvoChain,
-  StatsCalculate,
-} from '../../../utils/models/calculate.model';
+import { IBattleBaseStats, IQueryStatesEvoChain } from '../../../utils/models/calculate.model';
 import DynamicInputCP from '../../../components/Commons/Inputs/DynamicInputCP';
-import { IPokemonData } from '../../../core/models/pokemon.model';
 import { useTitle } from '../../../utils/hooks/useTitle';
-import {
-  combineClasses,
-  DynamicObj,
-  getValueOrDefault,
-  isEqual,
-  isInclude,
-  isIncludeList,
-  isNotEmpty,
-  toFloatWithPadding,
-  toNumber,
-} from '../../../utils/extension';
-import { LeagueBattleType } from '../../../core/enums/league.enum';
+import { combineClasses, isNotEmpty, toFloatWithPadding, toNumber } from '../../../utils/extension';
 import { getPokemonBattleLeagueIcon, getPokemonBattleLeagueName } from '../../../utils/compute';
 import { BattleLeagueCPType } from '../../../utils/enums/compute.enum';
+import { LeagueBattleType } from '../../../core/enums/league.enum';
 import { LinkToTop } from '../../../components/Link/LinkToTop';
 import {
   formNormal,
@@ -55,7 +31,6 @@ import {
 } from '../../../utils/helpers/options-context.helpers';
 import useAssets from '../../../composables/useAssets';
 import useSpinner from '../../../composables/useSpinner';
-import usePokemon from '../../../composables/usePokemon';
 import useSearch from '../../../composables/useSearch';
 import ButtonMui from '../../../components/Commons/Buttons/ButtonMui';
 import AccordionMui from '../../../components/Commons/Accordions/AccordionMui';
@@ -76,7 +51,6 @@ const FindBattle = () => {
       'PVP optimization',
     ],
   });
-  const { getFilteredPokemons, getFindPokemon } = usePokemon();
   const { getAssetNameById } = useAssets();
   const { hideSpinner, showSpinner } = useSpinner();
   const { searchingToolCurrentData } = useSearch();
@@ -96,6 +70,7 @@ const FindBattle = () => {
 
   const clearArrStats = () => {
     setSearchCP('');
+    setMaxCP(0);
     setEvoChain([]);
     setBestInLeague([]);
     setATKIv(0);
@@ -103,299 +78,72 @@ const FindBattle = () => {
     setSTAIv(0);
   };
 
-  const currEvoChain = useCallback(
-    (currId: number[], form: string, arr: IEvolution[]) => {
-      if (!isNotEmpty(currId)) {
-        return arr;
+  const onSearchStatsPoke = useCallback(
+    async (e: React.SyntheticEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (toNumber(searchCP) < minCp()) {
+        return showSnackbar(`Please input CP greater than or equal to ${minCp()}`, 'error');
       }
-      const curr = getFindPokemon((item) => isIncludeList(currId, item.num) && isInclude(item.form, form));
-      if (
-        !isIncludeList(
-          arr.map((i) => i.id),
-          curr?.num
-        )
-      ) {
-        arr.push({
-          ...curr,
-          form,
-          id: toNumber(curr?.num),
-          name: getValueOrDefault(String, curr?.pokemonId?.toString()),
-          pokemonId: curr?.pokemonId?.toString(),
-          evoList: getValueOrDefault(Array, curr?.evoList),
-          tempEvo: getValueOrDefault(Array, curr?.tempEvo),
-        });
+      const pokemonId = toNumber(searchingToolCurrentData?.form?.defaultId);
+      const name = splitAndCapitalize(searchingToolCurrentData?.pokemon?.fullName, '_', ' ');
+      if (!pokemonId) {
+        return showSnackbar('Please select a Pokémon before searching Battle League stats', 'error');
       }
-      currEvoChain(
-        getValueOrDefault(
-          Array,
-          curr?.evoList?.map((i) => i.evoToId)
-        ),
-        form,
-        arr
-      );
-    },
-    [getFindPokemon]
-  );
-
-  const prevEvoChain = useCallback(
-    (obj: IPokemonData, defaultForm: string, arr: IEvolution[], result: IEvolution[][]) => {
-      if (
-        !isIncludeList(
-          arr.map((i) => i.id),
-          obj.num
-        )
-      ) {
-        arr.push({
-          ...obj,
-          name: getValueOrDefault(String, obj.pokemonId?.toString()),
-          pokemonId: obj.pokemonId?.toString(),
-          id: obj.num,
-          evoList: getValueOrDefault(Array, obj.evoList),
-          tempEvo: getValueOrDefault(Array, obj.tempEvo),
-          form: defaultForm,
-        });
-      }
-      obj.evoList?.forEach((i) => {
-        currEvoChain([i.evoToId], i.evoToForm, arr);
-      });
-      const curr = getFilteredPokemons((item) =>
-        item.evoList?.some((i) => obj.num === i.evoToId && isEqual(i.evoToForm, defaultForm))
-      );
-      if (isNotEmpty(curr)) {
-        curr?.forEach((item) => prevEvoChain(item, defaultForm, arr, result));
-      } else {
-        result.push(arr);
-      }
-    },
-    [currEvoChain, getFilteredPokemons]
-  );
-
-  const getEvoChain = useCallback(
-    (id: number) => {
-      const currentForm = convertPokemonAPIDataName(searchingToolCurrentData?.form?.form?.formName, formNormal());
-      let curr = getFilteredPokemons((item) =>
-        item.evoList?.some((i) => id === i.evoToId && isEqual(currentForm, i.evoToForm))
-      );
-      if (!isNotEmpty(curr)) {
-        if (currentForm === formNormal()) {
-          curr = getFilteredPokemons((item) => id === item.num && isEqual(currentForm, item.form));
-        } else {
-          curr = getFilteredPokemons((item) => id === item.num && isInclude(item.form, currentForm));
-        }
-      }
-      if (!isNotEmpty(curr)) {
-        curr = getFilteredPokemons((item) => id === item.num && item.form === formNormal());
-      }
-      const result: IEvolution[][] = [];
-      curr?.forEach((item) => prevEvoChain(item, currentForm, [], result));
-      return result;
-    },
-    [prevEvoChain, searchingToolCurrentData?.form, getFilteredPokemons]
-  );
-
-  const searchStatsPoke = useCallback(
-    async (level: number) => {
+      showSpinner();
       try {
-        const sourceChains = getEvoChain(toNumber(searchingToolCurrentData?.form?.defaultId));
-        const requestChains = sourceChains.map((chain) =>
-          chain.map((value) => {
-            const pokemon = getFindPokemon(
-              (item) => item.num === value.id && (!value.form || isInclude(item.form, value.form))
-            );
-            const stats = calculateStatsByTag(pokemon, pokemon?.baseStats, pokemon?.slug);
-            return { id: value.id, name: value.name, form: value.form, atk: stats.atk, def: stats.def, sta: stats.sta };
-          })
-        );
-        const response = await APIService.getFetchUrl<{ data: BattleLeagueApiItem[][] }>(
-          APIService.getBattleLeagueStats({
-            chains: JSON.stringify(requestChains),
-            level,
-            atkIv: ATKIv,
-            defIv: DEFIv,
-            staIv: STAIv,
+        const response = await APIService.postBattleLeagueSearch({
+          id: pokemonId,
+          form: searchingToolCurrentData?.pokemon?.fullName,
+          cp: toNumber(searchCP),
+          iv: { atk: ATKIv, def: DEFIv, sta: STAIv },
+          config: {
             minLevel: minLevel(),
             maxLevel: maxLevel(),
             step: stepLevel(),
             minIv: minIv(),
             maxIv: maxIv(),
             minCp: minCp(),
-          })
-        );
-        const arr: IQueryStatesEvoChain[][] = response.data.data.map((chain, chainIndex) =>
-          chain.map((value) => {
-            const source = sourceChains[chainIndex]?.find(
-              (item) => item.id === value.id && (!value.form || isEqual(item.form, value.form))
-            );
-            const battleLeague = Object.fromEntries(
-              Object.entries(value.battleLeague).map(([name, battle]) => [
-                name,
-                battle.rank
-                  ? {
-                      ...battle,
-                      ...calculateBetweenLevel(
-                        value.atk,
-                        value.def,
-                        value.sta,
-                        ATKIv,
-                        DEFIv,
-                        STAIv,
-                        level,
-                        battle.level
-                      ),
-                    }
-                  : battle,
-              ])
-            ) as unknown as IQueryStatesEvoChain['battleLeague'];
-            return { ...source, ...value, battleLeague } as IQueryStatesEvoChain;
-          })
-        );
-        const current = arr.flat().find((item) => item.id === searchingToolCurrentData?.form?.defaultId);
-        if (current) {
-          setMaxCP(toNumber(current.maxCP));
-        }
-        setEvoChain(arr);
-        let currBastStats: IBattleBaseStats | undefined;
-        const evoBaseStats: IBattleBaseStats[] = [];
-        arr.forEach((item) => {
-          item.forEach((value) => {
-            if (value.id !== searchingToolCurrentData?.form?.defaultId) {
-              evoBaseStats.push(
-                BattleBaseStats.create({
-                  ...Object.values(value.battleLeague).reduce((a: IBattleBaseStats, b: IBattleBaseStats) =>
-                    !a ? b : !b ? a : toNumber(a.ratio) > toNumber(b.ratio) ? a : b
-                  ),
-                  id: value.id,
-                  name: value.name,
-                  form: value.form,
-                  maxCP: value.maxCP,
-                  league: Object.keys(value.battleLeague).reduce((a, b) =>
-                    !(value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[a]
-                      ? b
-                      : !(value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[b]
-                        ? a
-                        : toNumber((value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[a]?.ratio) >
-                            toNumber((value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[b]?.ratio)
-                          ? a
-                          : b
-                  ),
-                })
-              );
-            } else {
-              currBastStats = BattleBaseStats.create({
-                ...Object.values(value.battleLeague).reduce((a, b) =>
-                  !a ? b : !b ? a : toNumber(a.ratio) > toNumber(b.ratio) ? a : b
-                ),
-                id: value.id,
-                name: value.name,
-                form: value.form,
-                maxCP: value.maxCP,
-                league: Object.keys(value.battleLeague).reduce((a, b) =>
-                  !(value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[a]
-                    ? b
-                    : !(value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[b]
-                      ? a
-                      : toNumber((value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[a]?.ratio) >
-                          toNumber((value.battleLeague as unknown as DynamicObj<IBattleBaseStats>)[b]?.ratio)
-                        ? a
-                        : b
-                ),
-              });
-            }
-          });
+          },
         });
-        if (currBastStats) {
-          const ratio = toNumber(currBastStats.ratio);
-          let bestLeague = evoBaseStats.filter((item) => toNumber(item.ratio) > ratio);
-          bestLeague = bestLeague.filter(
-            (item) =>
-              (item.league === LeagueBattleType.Master && toNumber(item.CP) > BattleLeagueCPType.Ultra) ||
-              (item.league === LeagueBattleType.Ultra && toNumber(item.CP) > BattleLeagueCPType.Great) ||
-              (item.league === LeagueBattleType.Great && toNumber(item.CP) > BattleLeagueCPType.Little)
+        const result = response.data.data;
+        if (!result.possible) {
+          setMaxCP(0);
+          setEvoChain([]);
+          setBestInLeague([]);
+          showSnackbar(
+            `At CP: ${result.stats.CP} and IV ${result.stats.IV.atkIV}/${result.stats.IV.defIV}/${result.stats.IV.staIV} impossible found in ${name}`,
+            'error'
           );
-          if (!isNotEmpty(bestLeague)) {
-            bestLeague = evoBaseStats.filter((item) => toNumber(item.ratio) > ratio);
-          }
-          if (!isNotEmpty(bestLeague)) {
-            hideSpinner();
-            return setBestInLeague([currBastStats]);
-          }
-          if (ratio >= 90) {
-            bestLeague.push(currBastStats);
-          }
-          setBestInLeague(bestLeague.sort((a, b) => toNumber(a.maxCP) - toNumber(b.maxCP)));
-        } else {
-          setTimeout(() => showSnackbar(`Error! Something went wrong.`, 'error'), 300);
+          return;
         }
-        hideSpinner();
+        setMaxCP(result.maxCP);
+        setEvoChain(result.chains as IQueryStatesEvoChain[][]);
+        setBestInLeague(result.bestInLeague);
+        showSnackbar(
+          `Search success at CP: ${result.stats.CP} and IV ${result.stats.IV.atkIV}/${result.stats.IV.defIV}/${result.stats.IV.staIV} found in ${name}`,
+          'success'
+        );
       } catch {
-        hideSpinner();
+        setMaxCP(0);
+        setEvoChain([]);
+        setBestInLeague([]);
         showSnackbar('Battle League API is unavailable.', 'error');
+      } finally {
+        hideSpinner();
       }
-    },
-    [ATKIv, DEFIv, STAIv, getEvoChain, getFindPokemon, searchingToolCurrentData?.form?.defaultId]
-  );
-
-  const onSearchStatsPoke = useCallback(
-    (e: React.SyntheticEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      if (toNumber(searchCP) < minCp()) {
-        return showSnackbar(`Please input CP greater than or equal to ${minCp()}`, 'error');
-      }
-      showSpinner();
-      const statATK = toNumber(searchingToolCurrentData?.pokemon?.statsGO?.atk);
-      const statDEF = toNumber(searchingToolCurrentData?.pokemon?.statsGO?.def);
-      const statSTA = toNumber(searchingToolCurrentData?.pokemon?.statsGO?.sta);
-      setTimeout(() => {
-        const result = calculateStats(statATK, statDEF, statSTA, ATKIv, DEFIv, STAIv, searchCP);
-        processStatsPoke(result);
-      }, 200);
     },
     [
-      searchStatsPoke,
       ATKIv,
       DEFIv,
       STAIv,
       searchCP,
-      searchingToolCurrentData?.pokemon?.statsGO?.atk,
-      searchingToolCurrentData?.pokemon?.statsGO?.def,
-      searchingToolCurrentData?.pokemon?.statsGO?.sta,
+      searchingToolCurrentData?.pokemon?.fullName,
       searchingToolCurrentData?.form,
+      showSnackbar,
+      showSpinner,
+      hideSpinner,
     ]
   );
-
-  const processStatsPoke = (result: StatsCalculate) => {
-    const name = splitAndCapitalize(searchingToolCurrentData?.pokemon?.fullName, '_', ' ');
-    if (result.level === 0) {
-      hideSpinner();
-      return showSnackbar(
-        `At CP: ${result.CP} and IV ${result.IV.atkIV}/${result.IV.defIV}/${result.IV.staIV} impossible found in ${name}`,
-        'error'
-      );
-    }
-    setTimeout(() => {
-      searchStatsPoke(result.level);
-      showSnackbar(
-        `Search success at CP: ${result.CP} and IV ${result.IV.atkIV}/${result.IV.defIV}/${result.IV.staIV} found in ${name}`,
-        'success'
-      );
-    }, 500);
-  };
-
-  const getCandyEvo = (item: IEvolution[], evoId: number, candy = 0): number => {
-    if (evoId === searchingToolCurrentData?.form?.defaultId) {
-      return candy;
-    }
-    const data = item.find((i) => i.evoList.find((e) => e.evoToId === evoId));
-    if (!data) {
-      return candy;
-    }
-    const prevEvo = data.evoList.find((e) => e.evoToId === evoId);
-    if (!prevEvo) {
-      return candy;
-    }
-    candy += prevEvo.candyCost;
-    return getCandyEvo(item, data.id, candy);
-  };
 
   const getTextColorRatio = (value: number | undefined) => {
     value = toNumber(value);
@@ -421,7 +169,6 @@ const FindBattle = () => {
   };
 
   const renderPokemonBattleLeague = (
-    value: IQueryStatesEvoChain[],
     item: IQueryStatesEvoChain,
     battleStats: IBattleBaseStats,
     cp: BattleLeagueCPType
@@ -448,8 +195,10 @@ const FindBattle = () => {
             <span className="tw-flex tw-items-center">
               <Candy id={item.id} className="tw-mr-1" />
               <span className="tw-flex tw-items-center tw-mr-1">
-                {toNumber(battleStats.resultBetweenCandy) + getCandyEvo(value, item.id)}
-                <span className="tw-inline-block caption !tw-text-green-600">(+{getCandyEvo(value, item.id)})</span>
+                {toNumber(battleStats.resultBetweenCandy) + toNumber((item as BattleLeagueApiItem).evolutionCandy)}
+                <span className="tw-inline-block caption !tw-text-green-600">
+                  (+{toNumber((item as BattleLeagueApiItem).evolutionCandy)})
+                </span>
               </span>
               <CandyXL id={searchingToolCurrentData?.form?.defaultId} />
               {battleStats.resultBetweenXLCandy}
@@ -663,25 +412,13 @@ const FindBattle = () => {
                                   <Fragment>
                                     <hr />
                                     {renderPokemonBattleLeague(
-                                      value,
                                       item,
                                       item.battleLeague.little,
                                       BattleLeagueCPType.Little
                                     )}
+                                    {renderPokemonBattleLeague(item, item.battleLeague.great, BattleLeagueCPType.Great)}
+                                    {renderPokemonBattleLeague(item, item.battleLeague.ultra, BattleLeagueCPType.Ultra)}
                                     {renderPokemonBattleLeague(
-                                      value,
-                                      item,
-                                      item.battleLeague.great,
-                                      BattleLeagueCPType.Great
-                                    )}
-                                    {renderPokemonBattleLeague(
-                                      value,
-                                      item,
-                                      item.battleLeague.ultra,
-                                      BattleLeagueCPType.Ultra
-                                    )}
-                                    {renderPokemonBattleLeague(
-                                      value,
                                       item,
                                       item.battleLeague.master,
                                       BattleLeagueCPType.Master

--- a/src/pages/models/page.model.ts
+++ b/src/pages/models/page.model.ts
@@ -63,7 +63,4 @@ export interface IStatsDamageTableComponent {
   statATK: number | undefined;
   statDEF: number | undefined;
   statSTA: number | undefined;
-  setStatLvATK?: React.Dispatch<React.SetStateAction<number>>;
-  setStatLvDEF?: React.Dispatch<React.SetStateAction<number>>;
-  setStatLvSTA?: React.Dispatch<React.SetStateAction<number>>;
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, AxiosStatic, CancelTokenSource } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse, AxiosStatic, CancelTokenSource } from 'axios';
 import { APIUrl } from './constants';
 import type { PokemonBundle } from '../core/models/API/pokemon-bundle.model';
 import { getValueOrDefault, isEqual, isInclude } from '../utils/extension';
@@ -21,11 +21,22 @@ import {
   pathAssetPokeGo,
   unownId,
 } from '../utils/helpers/options-context.helpers';
+import type {
+  CalculateStatsApiResponse,
+  CalculateStatsRequest,
+  BattleLeagueSearchApiResponse,
+  BattleLeagueSearchRequest,
+  DamageSimulatorApiResponse,
+  DamageSimulatorRequest,
+  RaidBattleApiResponse,
+  RaidBattleRequest,
+} from './models/tools-api.model';
 
 class APIService {
   date: Date;
   axios: AxiosStatic;
   cancelToken: CancelTokenSource;
+  damageStatsCache = new Map<string, Promise<AxiosResponse<DamageSimulatorApiResponse>>>();
   publicGitHubRepos = ['pokeminers/pogo_assets', 'pvpoke/pvpoke'];
 
   constructor() {
@@ -465,6 +476,43 @@ class APIService {
 
   getDpsTdo(params: Record<string, string | number | boolean | undefined>) {
     return this.getInternalQueryUrl('dps-tdo', params);
+  }
+
+  postRaidBattle(payload: RaidBattleRequest) {
+    return this.axios.post<RaidBattleApiResponse>(`${APIUrl.POKEGO_BREEZE_API_URL}/api/v1/raid-battle`, payload);
+  }
+
+  postCalculateStats(payload: CalculateStatsRequest) {
+    return this.axios.post<CalculateStatsApiResponse>(
+      `${APIUrl.POKEGO_BREEZE_API_URL}/api/v1/calculate-stats`,
+      payload
+    );
+  }
+
+  postBattleLeagueSearch(payload: BattleLeagueSearchRequest) {
+    return this.axios.post<BattleLeagueSearchApiResponse>(
+      `${APIUrl.POKEGO_BREEZE_API_URL}/api/v1/battle-league-search`,
+      payload
+    );
+  }
+
+  postDamageSimulator(payload: DamageSimulatorRequest) {
+    const request = () =>
+      this.axios.post<DamageSimulatorApiResponse>(`${APIUrl.POKEGO_BREEZE_API_URL}/api/v1/damage-simulator`, payload);
+    if (payload.mode !== 'stats') {
+      return request();
+    }
+    const cacheKey = JSON.stringify(payload);
+    const cached = this.damageStatsCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const pending = request().catch((error) => {
+      this.damageStatsCache.delete(cacheKey);
+      throw error;
+    });
+    this.damageStatsCache.set(cacheKey, pending);
+    return pending;
   }
 
   getPokedex(params: Record<string, string | number | boolean | undefined>) {

--- a/src/services/models/tools-api.model.ts
+++ b/src/services/models/tools-api.model.ts
@@ -1,16 +1,52 @@
-import type { IBattleBaseStats, IQueryStatesEvoChain } from '../../utils/models/calculate.model';
+import type {
+  IBattleBaseStats,
+  IBattleLeagueCalculate,
+  IBetweenLevelCalculate,
+  IQueryStatesEvoChain,
+  IStatsCalculate,
+} from '../../utils/models/calculate.model';
 import type { IPokemonMoveData } from '../../core/models/pokemon.model';
 
 export interface BattleLeagueApiItem extends Omit<IQueryStatesEvoChain, 'battleLeague'> {
   atk: number;
   def: number;
   sta: number;
+  evolutionCandy: number;
   battleLeague: {
     little: IBattleBaseStats;
     great: IBattleBaseStats;
     ultra: IBattleBaseStats;
     master: IBattleBaseStats;
   };
+}
+
+export interface BattleLeagueSearchRequest {
+  id: number;
+  form?: string;
+  cp: number;
+  iv: { atk: number; def: number; sta: number };
+  config: {
+    minLevel: number;
+    maxLevel: number;
+    step: number;
+    minIv: number;
+    maxIv: number;
+    minCp: number;
+  };
+}
+
+type BattleLeagueSearchNotFound = { possible: false; stats: IStatsCalculate };
+type BattleLeagueSearchFound = {
+  possible: true;
+  stats: IStatsCalculate;
+  chains: BattleLeagueApiItem[][];
+  bestInLeague: IBattleBaseStats[];
+  maxCP: number;
+};
+
+export interface BattleLeagueSearchApiResponse {
+  data: BattleLeagueSearchNotFound | BattleLeagueSearchFound;
+  meta: { section: 'battleLeagueSearch' };
 }
 
 export type BreakpointApiResult =
@@ -22,9 +58,164 @@ export interface RaidApiResponse {
   data: IPokemonMoveData[];
   meta: {
     raidSummary?: {
-      dps?: { min: number; max: number };
-      tdo?: { min: number; max: number };
-      hp?: { min: number; max: number };
+      dps?: { min: number; max: number; average: number };
+      tdo?: { min: number; max: number; average: number };
+      hp?: { min: number; max: number; average: number };
+      suggestedPlayers?: { hard: number; easy: number };
     };
   };
+}
+
+export interface RaidBattleRequest {
+  boss: {
+    id: number;
+    form?: string;
+    fast: string;
+    charged: string;
+    atk: number;
+    def: number;
+    hp: number;
+    boost: boolean;
+  };
+  settings: {
+    timeAllow: number;
+    enableTimeAllow: boolean;
+    counterBoost: boolean;
+  };
+  trainers: Array<{
+    trainerId: number;
+    pokemons: Array<{
+      id: number;
+      form?: string;
+      fast: string;
+      charged: string;
+      level: number;
+      pokemonType: number;
+      iv: { atk: number; def: number; hp: number };
+      fMoveType?: number;
+      cMoveType?: number;
+    }>;
+  }>;
+}
+
+export interface RaidBattleApiResponse {
+  data: Array<{
+    pokemon: IPokemonMoveData[];
+    summary: {
+      dpsAtk: number;
+      dpsDef: number;
+      tdoAtk: number;
+      tdoDef: number;
+      timer: number;
+      bossHp: number;
+    };
+  }>;
+  meta: { section: 'raidBattle' };
+}
+
+export interface CalculateStatsRequest {
+  id: number;
+  form?: string;
+  cp: number;
+  pokemonType: number;
+  iv: { atk: number; def: number; sta: number };
+  config: { minCp: number; minLevel: number; maxLevel: number; step: number };
+}
+
+export interface CalculateStatsLevelResult extends IBetweenLevelCalculate {
+  stats: { atk: number; def: number; sta: number };
+}
+
+type CalculateStatsNotFound = {
+  possible: false;
+  stats: IStatsCalculate;
+};
+
+type CalculateStatsFound = {
+  possible: true;
+  stats: IStatsCalculate;
+  current: CalculateStatsLevelResult;
+  levels: Array<{ level: number; data: CalculateStatsLevelResult }>;
+  leagues: {
+    little: IBattleLeagueCalculate;
+    great: IBattleLeagueCalculate;
+    ultra: IBattleLeagueCalculate;
+    master: IBattleLeagueCalculate;
+  };
+};
+
+export interface CalculateStatsApiResponse {
+  data: CalculateStatsNotFound | CalculateStatsFound;
+  meta: { section: 'calculateStats' };
+}
+
+export interface DamageCalculatedStats {
+  level: number;
+  atk: number;
+  def: number;
+  sta: number;
+}
+
+export interface DamageStatsRequest {
+  mode: 'stats';
+  base: { atk: number; def: number; sta: number };
+  pokemonType: number;
+  iv: number;
+  config: { minLevel: number; maxLevel: number; step: number };
+}
+
+export interface DamageBattleRequest {
+  mode: 'damage';
+  attacker: {
+    base: { atk: number; def: number; sta: number };
+    level: number;
+    pokemonType: number;
+    types: string[];
+  };
+  defender: {
+    base: { atk: number; def: number; sta: number };
+    level: number;
+    pokemonType: number;
+    types: string[];
+  };
+  move: { type: string; power: number };
+  battle: {
+    isWb: boolean;
+    isDodge: boolean;
+    isTrainer: boolean;
+    friendshipLevel: number;
+    throwLevel: number;
+    isMega: boolean;
+  };
+  config: { iv: number; trainerMultiplier: number; megaMultiplier: number };
+}
+
+export type DamageSimulatorRequest = DamageStatsRequest | DamageBattleRequest;
+
+type DamageStatsResponse = {
+  mode: 'stats';
+  levels: DamageCalculatedStats[];
+};
+
+type DamageBattleResponse = {
+  mode: 'damage';
+  attackerStats: DamageCalculatedStats;
+  defenderStats: DamageCalculatedStats;
+  battleState: {
+    isStab: boolean;
+    isWb: boolean;
+    isDodge: boolean;
+    isTrainer: boolean;
+    friendshipLevel: number;
+    throwLevel: number;
+    effective: number;
+    isMega: boolean;
+  };
+  damage: number;
+  hp: number;
+};
+
+export interface DamageSimulatorApiResponse {
+  data: DamageStatsResponse | DamageBattleResponse;
+  meta: { section: 'damageSimulator' };
 }

--- a/src/utils/configs/processed-data-routes.config.ts
+++ b/src/utils/configs/processed-data-routes.config.ts
@@ -27,7 +27,7 @@ export const getProcessedDataSectionsForRoute = (pathname: string): ProcessedDat
     return ['pokemons', 'combats', 'assets', 'cpm', 'statsRankings'];
   }
   if (pathname === '/damage-calculate') {
-    return ['pokemons', 'combats', 'cpm', 'statsRankings'];
+    return ['pokemons', 'combats', 'statsRankings'];
   }
   if (pathname === '/calculate-catch-chance') {
     return ['pokemons', 'statsRankings'];


### PR DESCRIPTION
## Summary
- use API responses for Calculate Stats, Raid Battle, Damage Simulator, and Battle League Search
- remove duplicated heavy calculations from the browser
- handle empty DPS/TDO results without a stuck loading state

## Validation
- npm run lint
- npm run build:vite
- API production endpoint availability verified before Web promotion