### PR TITLE
Promote Firebase stale asset fix to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,22 @@ jobs:
             "cache-control: public, max-age=0, must-revalidate" \
             "$HEADERS_FILE"
 
+          ASSET_PATH=$(find dist/static/js -maxdepth 1 -type f -name '*.js' -printf '%P\n' | head -n 1)
+          ASSET_HEADERS_FILE="$RUNNER_TEMP/firebase-asset-headers.txt"
+          curl --fail --silent --show-error --retry 5 --retry-all-errors \
+            "$HOST/static/js/$ASSET_PATH" \
+            --dump-header "$ASSET_HEADERS_FILE" \
+            --output /dev/null
+          grep --fixed-strings --ignore-case --quiet \
+            "cache-control: public, max-age=31536000, immutable" \
+            "$ASSET_HEADERS_FILE"
+
+          MISSING_ASSET_STATUS=$(curl --silent --show-error \
+            "$HOST/static/js/__missing-asset-check__.js" \
+            --output /dev/null \
+            --write-out '%{http_code}')
+          test "$MISSING_ASSET_STATUS" = "404"
+
   # ─────────────────────────────────────────────────────────────────────────────
   # JOB 3 – Firebase Hosting: PR preview
   # ─────────────────────────────────────────────────────────────────────────────

--- a/firebase.json
+++ b/firebase.json
@@ -10,13 +10,13 @@
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }]
         },
         {
-          "source": "**/*.@(js|css|png|jpg|jpeg|gif|svg|ico|webp|woff|woff2)",
+          "source": "/static/**",
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
         }
       ],
       "rewrites": [
         {
-          "source": "**",
+          "source": "!/@(static)/**",
           "destination": "/index.html"
         }
       ]
@@ -31,13 +31,13 @@
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }]
         },
         {
-          "source": "**/*.@(js|css|png|jpg|jpeg|gif|svg|ico|webp|woff|woff2)",
+          "source": "/static/**",
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
         }
       ],
       "rewrites": [
         {
-          "source": "**",
+          "source": "!/@(static)/**",
           "destination": "/index.html"
         }
       ]
@@ -52,13 +52,13 @@
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }]
         },
         {
-          "source": "**/*.@(js|css|png|jpg|jpeg|gif|svg|ico|webp|woff|woff2)",
+          "source": "/static/**",
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
         }
       ],
       "rewrites": [
         {
-          "source": "**",
+          "source": "!/@(static)/**",
           "destination": "/index.html"
         }
       ]
@@ -73,13 +73,13 @@
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }]
         },
         {
-          "source": "**/*.@(js|css|png|jpg|jpeg|gif|svg|ico|webp|woff|woff2)",
+          "source": "/static/**",
           "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
         }
       ],
       "rewrites": [
         {
-          "source": "**",
+          "source": "!/@(static)/**",
           "destination": "/index.html"
         }
       ]

--- a/src/core/models/API/pokedex.model.ts
+++ b/src/core/models/API/pokedex.model.ts
@@ -13,3 +13,18 @@ export interface PokedexApiResponse {
     total: number;
   };
 }
+
+export const isPokedexApiResponse = (value: unknown): value is PokedexApiResponse => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const response = value as Partial<PokedexApiResponse>;
+  return (
+    Array.isArray(response.data) &&
+    !!response.meta &&
+    typeof response.meta.pages === 'number' &&
+    typeof response.meta.page === 'number' &&
+    typeof response.meta.total === 'number'
+  );
+};

--- a/src/pages/Pokedex/Pokedex.tsx
+++ b/src/pages/Pokedex/Pokedex.tsx
@@ -8,7 +8,7 @@ import APIService from '../../services/api.service';
 import { genList, regionList, versionList } from '../../utils/constants';
 import { Checkbox, FormControlLabel, ListItemText, Skeleton, Switch } from '@mui/material';
 import { IPokemonHomeModel, PokemonHomeModel } from '../../core/models/pokemon-home.model';
-import { PokedexApiResponse } from '../../core/models/API/pokedex.model';
+import { isPokedexApiResponse, PokedexApiResponse } from '../../core/models/API/pokedex.model';
 import { useTitle } from '../../utils/hooks/useTitle';
 import { PokemonClass, PokemonType } from '../../enums/type.enum';
 import { combineClasses, isEqual, isIncludeList, isNotEmpty, toNumber } from '../../utils/extension';
@@ -202,6 +202,9 @@ const Pokedex = (props: IStyleSheetData) => {
       .then(({ data }) => {
         if (requestId !== latestRequestRef.current) {
           return;
+        }
+        if (!isPokedexApiResponse(data)) {
+          throw new Error('The Pokédex service returned an invalid response. Please try again.');
         }
         const rows = data.data.map((item) => new PokemonHomeModel(item, item.assetForm));
         setPages(data.meta.pages);

--- a/src/pages/Search/Pokemon/Search.tsx
+++ b/src/pages/Search/Pokemon/Search.tsx
@@ -15,7 +15,11 @@ import usePokemon from '../../../composables/usePokemon';
 import useSearch from '../../../composables/useSearch';
 import SelectCardPokemon from '../../../components/Commons/Selects/SelectCardPokemon';
 import { useTitle } from '../../../utils/hooks/useTitle';
-import type { PokedexApiPokemon, PokedexApiResponse } from '../../../core/models/API/pokedex.model';
+import {
+  isPokedexApiResponse,
+  type PokedexApiPokemon,
+  type PokedexApiResponse,
+} from '../../../core/models/API/pokedex.model';
 
 const Search = () => {
   useTitle({
@@ -68,6 +72,9 @@ const Search = () => {
         .then(({ data }) => {
           if (requestId !== latestSearchRequest.current) {
             return;
+          }
+          if (!isPokedexApiResponse(data)) {
+            throw new Error('The Pokémon search service returned an invalid response.');
           }
           setSearchPages(data.meta.pages);
           setSearchResults((current) => {


### PR DESCRIPTION
## Summary
- prevent stale static bundles from falling through to index.html
- keep immutable caching scoped to generated static assets
- harden Pokédex and Pokémon search response handling
- verify Firebase asset behavior during deployment

## Stage verification
- CI, CodeQL, Checkly, and preview passed
- stage Vercel and Firebase deployments passed
- live missing-asset regression check returned 404